### PR TITLE
Gate analytics behind env vars and attribute signups to their acquisition source

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,12 +149,12 @@ Carriers apply their own rate limits and anti-spam policies, which vary by count
 </details>
 <details>
 <summary><b>Is it legal to send marketing SMS this way?</b></summary>
-SMS marketing is regulated in most countries (e.g., TCPA in the US, GDPR/ePrivacy in the EU). textbee is a tool — you are responsible for obtaining consent and complying with the laws that apply to you and your recipients.
+SMS marketing is regulated in most countries (e.g., TCPA in the US, GDPR/ePrivacy in the EU). textbee is a tool. You are responsible for obtaining consent and complying with the laws that apply to you and your recipients.
  
 </details>
 <details>
 <summary><b>Does my phone need to stay on?</b></summary>
-Yes — messages are sent through your phone, so it needs to be powered on with the app running and connected to the internet. A spare Android phone plugged into a charger works great as a dedicated gateway.
+Yes. Messages are sent through your phone, so it needs to be powered on with the app running and connected to the internet. A spare Android phone plugged into a charger works great as a dedicated gateway.
  
 </details>
 <details>
@@ -223,6 +223,45 @@ See [textbee.dev](https://textbee.dev) for current plans and limits. You can alw
    ```bash
    pnpm build
    ```
+
+### Analytics and telemetry
+
+**A self-hosted instance reports nothing to anyone by default.** With no
+analytics environment variables set, the web app loads no analytics or
+ad-platform scripts and the API sends no analytics events to any external
+service. Every provider below is opt-in, and one that is listed without its id
+is skipped.
+
+(This is separate from the services the API talks to when you configure them
+yourself: Firebase for push, Cloudflare Turnstile, Polar for billing, and your
+own SMTP server.)
+
+Web (`web/.env`, and the marketing site if you run it):
+
+| Variable | Purpose |
+| --- | --- |
+| `NEXT_PUBLIC_ANALYTICS_PROVIDERS` | Comma separated list of providers to load: `ga`, `clarity`, `meta`. Unset means none. |
+| `NEXT_PUBLIC_GA_MEASUREMENT_ID` | Google Analytics measurement id, required for `ga`. |
+| `NEXT_PUBLIC_CLARITY_PROJECT_ID` | Microsoft Clarity project id, required for `clarity`. |
+| `NEXT_PUBLIC_META_PIXEL_ID` | Meta pixel id, required for `meta`. |
+| `NEXT_PUBLIC_ATTRIBUTION_COOKIE_DOMAIN` | Cookie domain for signup attribution, for example `.example.com`, when the dashboard and the marketing site are on different subdomains. Leave unset for a single domain. |
+
+API (`api/.env`):
+
+| Variable | Purpose |
+| --- | --- |
+| `ANALYTICS_PROVIDERS` | Comma separated list of server-side destinations. Only `meta` today. Unset means no events are sent. |
+| `META_PIXEL_ID` | Same id as the browser pixel. |
+| `META_CAPI_ACCESS_TOKEN` | Conversions API token. Keep it out of version control and out of any `NEXT_PUBLIC_` variable. |
+| `META_CAPI_TEST_EVENT_CODE` | Optional. Routes events to Events Manager's test view instead of live reporting. |
+
+`NEXT_PUBLIC_` values are baked in at build time, so changing them means a
+rebuild, not just a restart. `ANALYTICS_PROVIDERS` on the API is read at
+runtime, so unsetting it and restarting stops all outbound events immediately.
+
+Signup attribution (which channel an account came from) is separate from the
+providers above. It is stored only in your own database, makes no external
+request, and is always on.
 
 ### Hosting on a VPS
 

--- a/api/.env.example
+++ b/api/.env.example
@@ -32,7 +32,7 @@ WEBHOOK_DELIVERY_TIMEOUT_MS=30000
 # Auto-disable webhook subscriptions with high failure rate (cron runs daily)
 WEBHOOK_AUTO_DISABLE_FAILURE_THRESHOLD=50
 WEBHOOK_AUTO_DISABLE_LOOKBACK_DAYS=30
-# Min failure rate 0–1 to disable (e.g. 0.50 = 50%; only disable when failures/total >= this)
+# Min failure rate 0 to 1 to disable (e.g. 0.50 = 50%; only disable when failures/total >= this)
 WEBHOOK_AUTO_DISABLE_MIN_FAILURE_RATE=0.50
 
 # SMS Queue Configuration
@@ -61,3 +61,21 @@ CLOUDFLARE_TURNSTILE_SECRET_KEY=1x0000000000000000000000000000000AA
 # the web app's NEXT_PUBLIC_GOOGLE_CLIENT_ID. Comma-separate for several clients.
 # When unset, the audience is not checked and a warning is logged.
 GOOGLE_CLIENT_ID=
+# Analytics and ad-platform conversion reporting.
+# Leave ANALYTICS_PROVIDERS unset and nothing is sent to any external service.
+# Comma separated, only "meta" is supported today. Reading it at runtime makes
+# it a kill switch: unset it and restart, no rebuild needed.
+ANALYTICS_PROVIDERS=
+META_PIXEL_ID=
+META_CAPI_ACCESS_TOKEN=
+# When set, events go to Events Manager > Test events instead of live
+# reporting. Remove it before running real campaigns.
+META_CAPI_TEST_EVENT_CODE=
+
+# Polar billing. Read by the code, so listed here even though a self-hosted
+# instance without billing can leave them empty.
+POLAR_ACCESS_TOKEN=
+POLAR_SERVER=sandbox
+POLAR_WEBHOOK_SECRET=
+POLAR_ORGANIZATION_ID=
+POLAR_DEFAULT_DISCOUNT_ID=

--- a/api/src/analytics/analytics.module.spec.ts
+++ b/api/src/analytics/analytics.module.spec.ts
@@ -1,0 +1,34 @@
+import { Injectable, Module } from '@nestjs/common'
+import { Test } from '@nestjs/testing'
+import { AnalyticsModule } from './analytics.module'
+import { AnalyticsService } from './analytics.service'
+
+// A DI mistake here would not fail a unit test, it would fail app boot, so the
+// wiring is checked directly: the module resolves, and a module that imports
+// nothing can still inject the service because AnalyticsModule is global.
+@Injectable()
+class ConsumerProbe {
+  constructor(readonly analytics: AnalyticsService) {}
+}
+
+@Module({ providers: [ConsumerProbe] })
+class ConsumerModule {}
+
+describe('AnalyticsModule', () => {
+  it('provides AnalyticsService', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AnalyticsModule],
+    }).compile()
+
+    expect(moduleRef.get(AnalyticsService)).toBeInstanceOf(AnalyticsService)
+  })
+
+  it('reaches a module that does not import it, because it is global', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AnalyticsModule, ConsumerModule],
+    }).compile()
+
+    const probe = moduleRef.get(ConsumerProbe, { strict: false })
+    expect(probe.analytics).toBeInstanceOf(AnalyticsService)
+  })
+})

--- a/api/src/analytics/analytics.module.ts
+++ b/api/src/analytics/analytics.module.ts
@@ -1,0 +1,12 @@
+import { Global, Module } from '@nestjs/common'
+import { AnalyticsService } from './analytics.service'
+import { MetaCapiService } from './meta-capi.service'
+
+// Global so auth, gateway and billing can report conversions without each
+// module importing it.
+@Global()
+@Module({
+  providers: [AnalyticsService, MetaCapiService],
+  exports: [AnalyticsService],
+})
+export class AnalyticsModule {}

--- a/api/src/analytics/analytics.service.spec.ts
+++ b/api/src/analytics/analytics.service.spec.ts
@@ -1,0 +1,142 @@
+import { AnalyticsService } from './analytics.service'
+
+describe('AnalyticsService', () => {
+  const originalEnv = process.env
+  const metaCapi = { send: jest.fn().mockResolvedValue(undefined) }
+  let service: AnalyticsService
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = { ...originalEnv }
+    service = new AnalyticsService(metaCapi as any)
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  const user = {
+    _id: 'user-1',
+    email: 'ada@example.com',
+    attribution: {
+      first: { fbclid: 'first-click', at: new Date(1000) },
+      last: { fbclid: 'last-click', at: new Date(2000) },
+      fbp: 'fb.1.2000.9',
+    },
+  }
+
+  describe('with no providers configured', () => {
+    beforeEach(() => {
+      delete process.env.ANALYTICS_PROVIDERS
+    })
+
+    it('sends nothing anywhere, which is the self-host default', () => {
+      service.userRegistered(user)
+      service.checkoutStarted(user, 'pro')
+      service.purchase(user, { amount: 1200, currency: 'usd' })
+
+      expect(metaCapi.send).not.toHaveBeenCalled()
+    })
+
+    it('stays silent for an empty or unrelated list too', () => {
+      process.env.ANALYTICS_PROVIDERS = ''
+      service.userRegistered(user)
+      process.env.ANALYTICS_PROVIDERS = 'something-else'
+      service.userRegistered(user)
+
+      expect(metaCapi.send).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('with meta enabled', () => {
+    beforeEach(() => {
+      process.env.ANALYTICS_PROVIDERS = 'meta'
+    })
+
+    it('reports a registration with the browser context', () => {
+      service.userRegistered(user, { ip: '203.0.113.4', userAgent: 'agent' })
+
+      expect(metaCapi.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'CompleteRegistration',
+          user: expect.objectContaining({
+            userId: 'user-1',
+            email: 'ada@example.com',
+            ip: '203.0.113.4',
+            userAgent: 'agent',
+          }),
+        }),
+      )
+    })
+
+    it('prefers the last click id, which is the one closest to the sale', () => {
+      service.userRegistered(user)
+
+      expect(metaCapi.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user: expect.objectContaining({ fbclid: 'last-click' }),
+        }),
+      )
+    })
+
+    it('falls back to the first click id when the last visit had none', () => {
+      service.userRegistered({
+        _id: 'user-2',
+        attribution: { first: { fbclid: 'only-click' }, last: {} },
+      })
+
+      expect(metaCapi.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user: expect.objectContaining({ fbclid: 'only-click' }),
+        }),
+      )
+    })
+
+    it('converts cents to a currency amount for a purchase', () => {
+      service.purchase(user, {
+        amount: 1200,
+        currency: 'usd',
+        plan: 'pro',
+        subscriptionId: 'sub_1',
+      })
+
+      expect(metaCapi.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Purchase',
+          idSuffix: 'sub_1',
+          customData: expect.objectContaining({
+            value: 12,
+            currency: 'USD',
+            content_name: 'pro',
+          }),
+        }),
+      )
+    })
+
+    it('sends no browser context for a purchase, which comes from a webhook', () => {
+      service.purchase(user, { amount: 1200, currency: 'usd' })
+
+      const sent = metaCapi.send.mock.calls[0][0]
+      expect(sent.user.ip).toBeUndefined()
+      expect(sent.user.userAgent).toBeUndefined()
+    })
+
+    it('names the plan on a checkout', () => {
+      service.checkoutStarted(user, 'scale')
+
+      expect(metaCapi.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'InitiateCheckout',
+          customData: { content_name: 'scale' },
+        }),
+      )
+    })
+
+    it('swallows a failure so a signup never breaks on an ad platform', async () => {
+      metaCapi.send.mockRejectedValueOnce(new Error('Meta is down'))
+
+      expect(() => service.userRegistered(user)).not.toThrow()
+      await new Promise((resolve) => setImmediate(resolve))
+    })
+  })
+})

--- a/api/src/analytics/analytics.service.ts
+++ b/api/src/analytics/analytics.service.ts
@@ -1,0 +1,132 @@
+import { Injectable, Logger } from '@nestjs/common'
+import { MetaCapiService, MetaUserContext } from './meta-capi.service'
+
+// Facade over every outbound analytics destination. Two rules hold for all of
+// them: nothing is sent unless ANALYTICS_PROVIDERS names the destination, and
+// nothing here can fail a request, because a signup must not break when an ad
+// platform is down.
+
+export type AnalyticsUser = {
+  _id?: any
+  email?: string
+  attribution?: {
+    first?: { fbclid?: string; at?: Date }
+    last?: { fbclid?: string; at?: Date }
+    fbp?: string
+  }
+}
+
+export type RequestContext = {
+  ip?: string
+  userAgent?: string
+}
+
+@Injectable()
+export class AnalyticsService {
+  private readonly logger = new Logger(AnalyticsService.name)
+
+  constructor(private readonly metaCapi: MetaCapiService) {}
+
+  private providers(): string[] {
+    return (process.env.ANALYTICS_PROVIDERS ?? '')
+      .split(',')
+      .map((name) => name.trim().toLowerCase())
+      .filter(Boolean)
+  }
+
+  private isEnabled(provider: string): boolean {
+    return this.providers().includes(provider)
+  }
+
+  private metaUser(
+    user: AnalyticsUser,
+    context?: RequestContext,
+  ): MetaUserContext {
+    // Last touch wins for the click id: it is the ad click closest to the
+    // conversion, which is the one Meta is trying to price.
+    const touch = user.attribution?.last?.fbclid
+      ? user.attribution.last
+      : user.attribution?.first
+
+    return {
+      userId: String(user._id ?? ''),
+      email: user.email,
+      ip: context?.ip,
+      userAgent: context?.userAgent,
+      fbclid: touch?.fbclid,
+      fbclidAt: touch?.at,
+      fbp: user.attribution?.fbp,
+    }
+  }
+
+  private dispatch(name: string, send: () => Promise<void>) {
+    send().catch((error) => {
+      this.logger.warn(`Failed to send ${name}: ${error?.message ?? error}`)
+    })
+  }
+
+  userRegistered(user: AnalyticsUser, context?: RequestContext) {
+    if (!this.isEnabled('meta')) return
+    this.dispatch('CompleteRegistration', () =>
+      this.metaCapi.send({
+        name: 'CompleteRegistration',
+        user: this.metaUser(user, context),
+        sourcePath: '/register',
+      }),
+    )
+  }
+
+  checkoutStarted(
+    user: AnalyticsUser,
+    plan: string,
+    context?: RequestContext,
+  ) {
+    if (!this.isEnabled('meta')) return
+    this.dispatch('InitiateCheckout', () =>
+      this.metaCapi.send({
+        name: 'InitiateCheckout',
+        user: this.metaUser(user, context),
+        sourcePath: `/checkout/${plan}`,
+        customData: { content_name: plan },
+      }),
+    )
+  }
+
+  /**
+   * Only for the first time an account starts paying. Callers gate this on
+   * markMilestone('firstPaidAt') so renewals, upgrades and re-subscribes never
+   * report a second sale.
+   */
+  purchase(
+    user: AnalyticsUser,
+    {
+      amount,
+      currency,
+      plan,
+      subscriptionId,
+    }: {
+      amount?: number
+      currency?: string
+      plan?: string
+      subscriptionId?: string
+    },
+  ) {
+    if (!this.isEnabled('meta')) return
+    this.dispatch('Purchase', () =>
+      this.metaCapi.send({
+        name: 'Purchase',
+        // No ip or user agent: this originates from a billing webhook, so the
+        // only honest browser context is none.
+        user: this.metaUser(user),
+        sourcePath: '/dashboard/account',
+        idSuffix: subscriptionId,
+        customData: {
+          // Polar reports money in cents.
+          value: typeof amount === 'number' ? amount / 100 : undefined,
+          currency: (currency ?? 'usd').toUpperCase(),
+          ...(plan && { content_name: plan }),
+        },
+      }),
+    )
+  }
+}

--- a/api/src/analytics/meta-capi.service.spec.ts
+++ b/api/src/analytics/meta-capi.service.spec.ts
@@ -1,0 +1,157 @@
+import axios from 'axios'
+import { createHash } from 'crypto'
+import { MetaCapiService } from './meta-capi.service'
+
+jest.mock('axios')
+const mockedAxios = axios as jest.Mocked<typeof axios>
+
+const sha256 = (value: string) =>
+  createHash('sha256').update(value).digest('hex')
+
+describe('MetaCapiService', () => {
+  const originalEnv = process.env
+  let service: MetaCapiService
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = { ...originalEnv }
+    process.env.META_PIXEL_ID = '1603269904673257'
+    process.env.META_CAPI_ACCESS_TOKEN = 'test-token'
+    process.env.FRONTEND_URL = 'https://app.example.com'
+    delete process.env.META_CAPI_TEST_EVENT_CODE
+    mockedAxios.post.mockResolvedValue({ data: {} } as any)
+    service = new MetaCapiService()
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  const send = () =>
+    service.send({
+      name: 'CompleteRegistration',
+      user: {
+        userId: 'user-1',
+        email: '  Ada@Example.COM ',
+        ip: '203.0.113.4',
+        userAgent: 'Mozilla/5.0',
+        fbclid: 'click-1',
+        fbclidAt: new Date(1757577600000),
+        fbp: 'fb.1.1757577600000.99',
+      },
+      sourcePath: '/register',
+    })
+
+  const lastBody = () => mockedAxios.post.mock.calls[0][1] as any
+  const lastUrl = () => mockedAxios.post.mock.calls[0][0] as string
+
+  it('sends nothing when the pixel or token is missing', async () => {
+    delete process.env.META_CAPI_ACCESS_TOKEN
+    await send()
+    expect(mockedAxios.post).not.toHaveBeenCalled()
+
+    process.env.META_CAPI_ACCESS_TOKEN = 'test-token'
+    delete process.env.META_PIXEL_ID
+    await send()
+    expect(mockedAxios.post).not.toHaveBeenCalled()
+  })
+
+  it('posts to the pixel events endpoint on a pinned api version', async () => {
+    await send()
+    expect(lastUrl()).toMatch(
+      /^https:\/\/graph\.facebook\.com\/v\d+\.\d+\/1603269904673257\/events$/,
+    )
+  })
+
+  it('keeps the access token out of the url', async () => {
+    await send()
+    expect(lastUrl()).not.toContain('access_token')
+    expect(lastBody().access_token).toBe('test-token')
+  })
+
+  it('includes event_time in seconds, which Meta rejects the event without', async () => {
+    await send()
+    const event = lastBody().data[0]
+
+    expect(typeof event.event_time).toBe('number')
+    expect(Number.isInteger(event.event_time)).toBe(true)
+    // Seconds, not milliseconds: a millisecond value would be far in the future.
+    expect(Math.abs(event.event_time - Date.now() / 1000)).toBeLessThan(60)
+  })
+
+  it('hashes the email and the account id, and normalises the email first', async () => {
+    await send()
+    const userData = lastBody().data[0].user_data
+
+    expect(userData.em).toBe(sha256('ada@example.com'))
+    expect(userData.em).not.toContain('@')
+    expect(userData.external_id).toBe(sha256('user-1'))
+    expect(JSON.stringify(lastBody())).not.toContain('Ada@Example.COM')
+  })
+
+  it('formats the click id the way Meta expects', async () => {
+    await send()
+    expect(lastBody().data[0].user_data.fbc).toBe('fb.1.1757577600000.click-1')
+    expect(lastBody().data[0].user_data.fbp).toBe('fb.1.1757577600000.99')
+  })
+
+  it('passes browser context only when there is any', async () => {
+    await service.send({
+      name: 'Purchase',
+      user: { userId: 'user-2', email: 'a@b.com' },
+      customData: { value: 12.5, currency: 'USD' },
+    })
+    const userData = lastBody().data[0].user_data
+
+    expect(userData.client_ip_address).toBeUndefined()
+    expect(userData.client_user_agent).toBeUndefined()
+    expect(userData.fbc).toBeUndefined()
+  })
+
+  it('builds a stable event id so a retry deduplicates', async () => {
+    await send()
+    expect(lastBody().data[0].event_id).toBe('CompleteRegistration:user-1')
+
+    jest.clearAllMocks()
+    await service.send({
+      name: 'Purchase',
+      user: { userId: 'user-1' },
+      idSuffix: 'sub_123',
+    })
+    expect(lastBody().data[0].event_id).toBe('Purchase:user-1:sub_123')
+  })
+
+  it('puts the test event code beside data, not inside the event', async () => {
+    process.env.META_CAPI_TEST_EVENT_CODE = 'TEST123'
+    await send()
+
+    expect(lastBody().test_event_code).toBe('TEST123')
+    expect(lastBody().data[0].test_event_code).toBeUndefined()
+  })
+
+  it('omits the test event code once it is unset', async () => {
+    await send()
+    expect(lastBody().test_event_code).toBeUndefined()
+  })
+
+  it('carries custom data and the source url', async () => {
+    await service.send({
+      name: 'Purchase',
+      user: { userId: 'user-3' },
+      sourcePath: '/dashboard/account',
+      customData: { value: 6, currency: 'USD' },
+    })
+    const event = lastBody().data[0]
+
+    expect(event.custom_data).toEqual({ value: 6, currency: 'USD' })
+    expect(event.event_source_url).toBe(
+      'https://app.example.com/dashboard/account',
+    )
+    expect(event.action_source).toBe('website')
+  })
+
+  it('gives up rather than hanging on a slow response', async () => {
+    await send()
+    expect(mockedAxios.post.mock.calls[0][2]).toMatchObject({ timeout: 5000 })
+  })
+})

--- a/api/src/analytics/meta-capi.service.ts
+++ b/api/src/analytics/meta-capi.service.ts
@@ -1,0 +1,105 @@
+import { Injectable, Logger } from '@nestjs/common'
+import axios from 'axios'
+import { createHash } from 'crypto'
+
+// Pinned rather than floating. Meta retires a version roughly every two years,
+// and a silently stale one stops reporting conversions mid-campaign.
+const GRAPH_API_VERSION = 'v23.0'
+const REQUEST_TIMEOUT_MS = 5000
+
+export type MetaUserContext = {
+  userId: string
+  email?: string
+  // Only present when a browser request is the origin. A Polar webhook must not
+  // supply Polar's own address, which would poison match quality.
+  ip?: string
+  userAgent?: string
+  fbclid?: string
+  fbclidAt?: Date
+  fbp?: string
+}
+
+export type MetaEvent = {
+  name: 'CompleteRegistration' | 'InitiateCheckout' | 'Purchase'
+  user: MetaUserContext
+  sourcePath?: string
+  // Appended to the user id so a retry of the same conversion deduplicates but
+  // a genuinely different one does not.
+  idSuffix?: string
+  customData?: Record<string, unknown>
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+@Injectable()
+export class MetaCapiService {
+  private readonly logger = new Logger(MetaCapiService.name)
+
+  isConfigured(): boolean {
+    return Boolean(
+      process.env.META_PIXEL_ID && process.env.META_CAPI_ACCESS_TOKEN,
+    )
+  }
+
+  private userData(user: MetaUserContext): Record<string, unknown> {
+    const data: Record<string, unknown> = {
+      external_id: sha256(user.userId),
+    }
+
+    if (user.email) data.em = sha256(user.email.trim().toLowerCase())
+    if (user.ip) data.client_ip_address = user.ip
+    if (user.userAgent) data.client_user_agent = user.userAgent
+    if (user.fbp) data.fbp = user.fbp
+
+    // Meta's documented click-id format: fb.<subdomain index>.<click time in
+    // milliseconds>.<fbclid>.
+    if (user.fbclid) {
+      const clickedAt = user.fbclidAt?.getTime() ?? Date.now()
+      data.fbc = `fb.1.${clickedAt}.${user.fbclid}`
+    }
+
+    return data
+  }
+
+  async send(event: MetaEvent): Promise<void> {
+    if (!this.isConfigured()) return
+
+    const eventId = event.idSuffix
+      ? `${event.name}:${event.user.userId}:${event.idSuffix}`
+      : `${event.name}:${event.user.userId}`
+
+    const body: Record<string, unknown> = {
+      data: [
+        {
+          event_name: event.name,
+          // Unix seconds, and Meta rejects anything older than seven days.
+          event_time: Math.floor(Date.now() / 1000),
+          event_id: eventId,
+          action_source: 'website',
+          event_source_url: `${
+            process.env.FRONTEND_URL ?? 'https://app.textbee.dev'
+          }${event.sourcePath ?? '/'}`,
+          user_data: this.userData(event.user),
+          ...(event.customData && { custom_data: event.customData }),
+        },
+      ],
+      // In the body, never the query string: the token is a long-lived secret
+      // and query strings end up in proxy and error logs.
+      access_token: process.env.META_CAPI_ACCESS_TOKEN,
+    }
+
+    if (process.env.META_CAPI_TEST_EVENT_CODE) {
+      body.test_event_code = process.env.META_CAPI_TEST_EVENT_CODE
+    }
+
+    await axios.post(
+      `https://graph.facebook.com/${GRAPH_API_VERSION}/${process.env.META_PIXEL_ID}/events`,
+      body,
+      { timeout: REQUEST_TIMEOUT_MS },
+    )
+
+    this.logger.log(`Sent ${event.name} to Meta (${eventId})`)
+  }
+}

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -19,6 +19,7 @@ import { BillingModule } from './billing/billing.module'
 import { ConfigModule, ConfigService } from '@nestjs/config'
 import { BullModule } from '@nestjs/bull'
 import { SupportModule } from './support/support.module'
+import { AnalyticsModule } from './analytics/analytics.module'
 import { EventEmitterModule } from '@nestjs/event-emitter'
 
 @Injectable()
@@ -59,6 +60,7 @@ export class LoggerMiddleware implements NestMiddleware {
     WebhookModule,
     BillingModule,
     SupportModule,
+    AnalyticsModule,
   ],
   controllers: [],
   providers: [

--- a/api/src/auth/auth.controller.ts
+++ b/api/src/auth/auth.controller.ts
@@ -103,8 +103,12 @@ export class AuthController {
   })
   @HttpCode(HttpStatus.OK)
   @Post('/google-login')
-  async googleLogin(@Body() input: GoogleLoginInputDTO) {
-    const data = await this.authService.loginWithGoogle(input.idToken)
+  async googleLogin(@Body() input: GoogleLoginInputDTO, @Request() req) {
+    const data = await this.authService.loginWithGoogle(input.idToken, {
+      attribution: input.attribution,
+      ip: req.ip,
+      userAgent: req.headers?.['user-agent'],
+    })
     return { data }
   }
 
@@ -123,8 +127,11 @@ export class AuthController {
     description: 'The email is already in use, or the Turnstile check failed.',
   })
   @Post('/register')
-  async register(@Body() input: RegisterInputDTO) {
-    const data = await this.authService.register(input)
+  async register(@Body() input: RegisterInputDTO, @Request() req) {
+    const data = await this.authService.register(input, {
+      ip: req.ip,
+      userAgent: req.headers?.['user-agent'],
+    })
     return { data }
   }
 

--- a/api/src/auth/auth.dto.ts
+++ b/api/src/auth/auth.dto.ts
@@ -1,5 +1,112 @@
 import { ApiProperty } from '@nestjs/swagger'
 
+export class AttributionTouchDTO {
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'utm_source from the link that was followed.',
+    example: 'meta',
+  })
+  source?: string
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'utm_medium from the link that was followed.',
+    example: 'paid_social',
+  })
+  medium?: string
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'utm_campaign from the link that was followed.',
+  })
+  campaign?: string
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'utm_content from the link that was followed.',
+  })
+  content?: string
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'utm_term from the link that was followed.',
+  })
+  term?: string
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Value of a plain ref query parameter, used by short links.',
+  })
+  ref?: string
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description:
+      'Hostname of the referring site. Same-site referrers are not recorded.',
+    example: 'news.ycombinator.com',
+  })
+  referrer?: string
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Path the visitor landed on.',
+    example: '/pricing',
+  })
+  landingPath?: string
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Meta advertising click identifier from the address.',
+  })
+  fbclid?: string
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Google advertising click identifier from the address.',
+  })
+  gclid?: string
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'When the visit happened, as an ISO timestamp.',
+  })
+  at?: string
+}
+
+export class AttributionDTO {
+  @ApiProperty({
+    type: AttributionTouchDTO,
+    required: false,
+    description: 'The visit that first brought this person to the site.',
+  })
+  first?: AttributionTouchDTO
+
+  @ApiProperty({
+    type: AttributionTouchDTO,
+    required: false,
+    description: 'The most recent visit that carried a source.',
+  })
+  last?: AttributionTouchDTO
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "Meta's browser cookie value, used to match ad clicks.",
+  })
+  fbp?: string
+}
+
 export class RegisterInputDTO {
   @ApiProperty({
     type: String,
@@ -30,6 +137,22 @@ export class RegisterInputDTO {
     description: 'Password for the new account.',
   })
   password: string
+
+  @ApiProperty({
+    type: Boolean,
+    required: false,
+    description:
+      'Whether the person agreed to receive product and promotional email.',
+  })
+  marketingOptIn?: boolean
+
+  @ApiProperty({
+    type: AttributionDTO,
+    required: false,
+    description:
+      'Where this signup came from, as captured by the site. Unknown fields are discarded.',
+  })
+  attribution?: AttributionDTO
 
   @ApiProperty({
     type: String,
@@ -67,6 +190,14 @@ export class GoogleLoginInputDTO {
       'Google ID token from the browser sign-in flow. It must be issued for the textbee client and carry a verified email.',
   })
   idToken: string
+
+  @ApiProperty({
+    type: AttributionDTO,
+    required: false,
+    description:
+      'Where this signup came from. Recorded only when this call creates the account.',
+  })
+  attribution?: AttributionDTO
 }
 
 export class RequestResetPasswordInputDTO {
@@ -225,6 +356,14 @@ export class AuthSessionDTO {
 
   @ApiProperty({ type: UserDTO, description: 'The signed in account.' })
   user: UserDTO
+
+  @ApiProperty({
+    type: Boolean,
+    required: false,
+    description:
+      'True when this request created the account, as opposed to signing in to an existing one. Only returned by the Google endpoint.',
+  })
+  isNewUser?: boolean
 }
 
 export class AuthSessionResponseDTO {

--- a/api/src/auth/auth.service.spec.ts
+++ b/api/src/auth/auth.service.spec.ts
@@ -69,13 +69,35 @@ describe('AuthService', () => {
       await expect(service.validateEmail('a@b.com')).resolves.toBeUndefined()
     })
 
-    it.each(['plainaddress', 'no-at-sign.com', 'missing@dot', '@no-local.com'])(
-      'rejects %s',
-      async (bad) => {
-        const { service } = build()
-        await expect(service.validateEmail(bad)).rejects.toThrow(HttpException)
-      },
-    )
+    it('tolerates surrounding whitespace', async () => {
+      const { service } = build()
+      await expect(service.validateEmail('  a@b.com  ')).resolves.toBeUndefined()
+    })
+
+    it.each([
+      'plainaddress',
+      'no-at-sign.com',
+      'missing@dot',
+      '@no-local.com',
+      // Used to pass: the pattern was unanchored, so any substring matched.
+      'hello a@b.com world',
+      'a b@c.com',
+      undefined as any,
+      null as any,
+    ])('rejects %s', async (bad) => {
+      const { service } = build()
+      await expect(service.validateEmail(bad)).rejects.toThrow(HttpException)
+    })
+
+    it('rejects an over-long address without scanning it', async () => {
+      const { service } = build()
+      const huge = `${'!'.repeat(100000)}@b.com`
+
+      const startedAt = Date.now()
+      await expect(service.validateEmail(huge)).rejects.toThrow(HttpException)
+      // The old unanchored pattern backtracked on input like this.
+      expect(Date.now() - startedAt).toBeLessThan(1000)
+    })
   })
 
   describe('validatePassword', () => {

--- a/api/src/auth/auth.service.spec.ts
+++ b/api/src/auth/auth.service.spec.ts
@@ -26,11 +26,17 @@ const build = () => {
     findOne: jest.fn(),
     findOneWithPassword: jest.fn(),
     create: jest.fn(),
+    markMilestone: jest.fn().mockResolvedValue(false),
   }
   const passwordResetModel = { findOne: jest.fn(), findOneAndUpdate: jest.fn() }
   const mailService = { sendEmailFromTemplate: jest.fn().mockResolvedValue(undefined) }
   const jwtService = { sign: jest.fn().mockReturnValue('signed-jwt') }
   const turnstileService = { verify: jest.fn().mockResolvedValue(undefined) }
+  const analyticsService = {
+    userRegistered: jest.fn(),
+    checkoutStarted: jest.fn(),
+    purchase: jest.fn(),
+  }
 
   const service = new AuthService(
     usersService as any,
@@ -41,6 +47,7 @@ const build = () => {
     {} as any, // emailVerificationModel
     mailService as any,
     turnstileService as any,
+    analyticsService as any,
   )
 
   return {

--- a/api/src/auth/auth.service.ts
+++ b/api/src/auth/auth.service.ts
@@ -684,8 +684,15 @@ export class AuthService {
   }
 
   async validateEmail(email: string) {
-    const re = /\S+@\S+\.\S+/
-    if (!re.test(email)) {
+    // Anchored, with character classes that cannot overlap, and bounded by the
+    // RFC length limit. The previous pattern was unanchored \S+@\S+\.\S+,
+    // whose repeated \S+ groups backtrack polynomially on a long run of
+    // non-space characters. Registration is unauthenticated and accepts a large
+    // body, so that was reachable by anyone.
+    const re = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+    const candidate = typeof email === 'string' ? email.trim() : ''
+
+    if (candidate.length > 254 || !re.test(candidate)) {
       throw new HttpException(
         { error: 'Invalid email' },
         HttpStatus.BAD_REQUEST,

--- a/api/src/auth/auth.service.ts
+++ b/api/src/auth/auth.service.ts
@@ -1,5 +1,7 @@
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common'
 import { UsersService } from '../users/users.service'
+import { sanitizeAttribution } from '../users/attribution'
+import { AnalyticsService } from '../analytics/analytics.service'
 import { JwtService } from '@nestjs/jwt'
 import * as bcrypt from 'bcryptjs'
 import { createHash, randomInt } from 'crypto'
@@ -50,6 +52,7 @@ export class AuthService {
     private emailVerificationModel: Model<EmailVerificationDocument>,
     private readonly mailService: MailService,
     private readonly turnstileService: TurnstileService,
+    private readonly analyticsService: AnalyticsService,
   ) {}
 
   async login(userData: any) {
@@ -114,7 +117,14 @@ export class AuthService {
     }
   }
 
-  async loginWithGoogle(idToken: string) {
+  async loginWithGoogle(
+    idToken: string,
+    signupContext?: {
+      attribution?: unknown
+      ip?: string
+      userAgent?: string
+    },
+  ) {
     const response = await axios.get(
       `https://oauth2.googleapis.com/tokeninfo?id_token=${encodeURIComponent(
         idToken,
@@ -126,10 +136,16 @@ export class AuthService {
     const { sub: googleId, name, email, picture } = response.data
     let user = await this.usersService.findOne({ email })
 
+    // The same button serves sign-in and sign-up, so attribution is sent every
+    // time and applied only when this call is what creates the account.
+    const isNewUser = !user
+
     if (!user) {
       user = await this.usersService.create({
         name,
         email,
+        attribution: sanitizeAttribution(signupContext?.attribution),
+        userAgent: signupContext?.userAgent,
       })
     }
 
@@ -152,14 +168,25 @@ export class AuthService {
     user.lastLoginAt = new Date()
     await user.save()
 
+    if (isNewUser) {
+      this.analyticsService.userRegistered(user as any, {
+        ip: signupContext?.ip,
+        userAgent: signupContext?.userAgent,
+      })
+    }
+
     const payload = { email: user.email, sub: user._id }
     return {
       accessToken: this.jwtService.sign(payload),
       user: withoutPassword(user),
+      isNewUser,
     }
   }
 
-  async register(userData: any) {
+  async register(
+    userData: any,
+    requestContext?: { ip?: string; userAgent?: string },
+  ) {
     await this.turnstileService.verify(userData.turnstileToken)
 
     const existingUser = await this.usersService.findOne({
@@ -176,14 +203,23 @@ export class AuthService {
     await this.validatePassword(userData.password)
 
     const hashedPassword = await bcrypt.hash(userData.password, 10)
-    const { turnstileToken, ...sanitizedUserData } = userData
+    // Named explicitly rather than spread: the request body is attacker
+    // controlled and there is no global ValidationPipe, so spreading it would
+    // let any field reach the document.
     const user = await this.usersService.create({
-      ...sanitizedUserData,
+      name: userData.name,
+      email: userData.email,
+      phone: userData.phone,
       password: hashedPassword,
+      marketingOptIn: userData.marketingOptIn === true,
+      attribution: sanitizeAttribution(userData.attribution),
+      userAgent: requestContext?.userAgent,
     })
 
     user.lastLoginAt = new Date()
     await user.save()
+
+    this.analyticsService.userRegistered(user as any, requestContext)
 
     this.sendEmailVerificationEmail(user).catch((e) => {
       console.log('Failed to send email verification email')
@@ -453,6 +489,12 @@ export class AuthService {
     })
 
     await newApiKey.save()
+
+    // Activation milestone. Fire and forget: a reporting write must not fail
+    // the call that just handed the caller a key they cannot see again.
+    this.usersService
+      .markMilestone(currentUser._id, 'firstApiKeyAt')
+      .catch(() => undefined)
 
     return { apiKey, message: 'Save this key, it wont be shown again ;)' }
   }

--- a/api/src/billing/billing.service.spec.ts
+++ b/api/src/billing/billing.service.spec.ts
@@ -9,6 +9,8 @@ import { SMS } from '../gateway/schemas/sms.schema'
 import { PolarWebhookPayload } from './schemas/polar-webhook-payload.schema'
 import { CheckoutSession } from './schemas/checkout-session.schema'
 import { BillingNotificationsService } from './billing-notifications.service'
+import { UsersService } from '../users/users.service'
+import { AnalyticsService } from '../analytics/analytics.service'
 
 describe('BillingService - cancellation handling', () => {
   let service: BillingService
@@ -26,6 +28,12 @@ describe('BillingService - cancellation handling', () => {
   }
   const emptyModel = {}
   const mockBillingNotifications = {}
+  const mockUsersService = { markMilestone: jest.fn() }
+  const mockAnalyticsService = {
+    userRegistered: jest.fn(),
+    checkoutStarted: jest.fn(),
+    purchase: jest.fn(),
+  }
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -50,12 +58,15 @@ describe('BillingService - cancellation handling', () => {
           provide: BillingNotificationsService,
           useValue: mockBillingNotifications,
         },
+        { provide: UsersService, useValue: mockUsersService },
+        { provide: AnalyticsService, useValue: mockAnalyticsService },
       ],
     }).compile()
 
     service = module.get<BillingService>(BillingService)
 
     jest.clearAllMocks()
+    mockUsersService.markMilestone.mockResolvedValue(false)
     mockPlanModel.findOne.mockResolvedValue(proPlan)
     mockSubscriptionModel.updateOne.mockResolvedValue({ modifiedCount: 1 })
   })
@@ -166,6 +177,8 @@ describe('BillingService - checkout guards', () => {
         },
         { provide: getModelToken(CheckoutSession.name), useValue: emptyModel },
         { provide: BillingNotificationsService, useValue: {} },
+        { provide: UsersService, useValue: { markMilestone: jest.fn() } },
+        { provide: AnalyticsService, useValue: { purchase: jest.fn(), checkoutStarted: jest.fn() } },
       ],
     }).compile()
 
@@ -240,6 +253,8 @@ describe('BillingService - syncCheckoutSessionStatus', () => {
           useValue: mockCheckoutSessionModel,
         },
         { provide: BillingNotificationsService, useValue: {} },
+        { provide: UsersService, useValue: { markMilestone: jest.fn() } },
+        { provide: AnalyticsService, useValue: { purchase: jest.fn(), checkoutStarted: jest.fn() } },
       ],
     }).compile()
 
@@ -321,5 +336,129 @@ describe('BillingService - syncCheckoutSessionStatus', () => {
         status: 'succeeded',
       }),
     ).resolves.not.toThrow()
+  })
+})
+
+/*
+ * Reporting a sale to an ad platform more than once teaches it to bid on the
+ * wrong thing, so the first-payment event has to survive the shapes Polar
+ * actually sends: created then active for one signup, an upgrade that creates a
+ * second subscription row, a renewal, and a re-subscribe after a revoke.
+ */
+describe('BillingService - first payment reporting', () => {
+  let service: BillingService
+
+  const userId = '507f1f77bcf86cd799439011'
+  const proPlan = { _id: 'plan_pro', name: 'pro' }
+
+  const mockPlanModel = { findOne: jest.fn() }
+  const mockSubscriptionModel = { updateMany: jest.fn(), updateOne: jest.fn() }
+  const mockUserModel = { findById: jest.fn() }
+  const mockUsersService = { markMilestone: jest.fn() }
+  const mockAnalyticsService = { purchase: jest.fn(), checkoutStarted: jest.fn() }
+  const emptyModel = {}
+
+  const activePayment = {
+    userId,
+    newPlanName: 'pro',
+    status: 'active',
+    amount: 1200,
+    currency: 'usd',
+    polarSubscriptionId: 'sub_1',
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BillingService,
+        { provide: getModelToken(Plan.name), useValue: mockPlanModel },
+        {
+          provide: getModelToken(Subscription.name),
+          useValue: mockSubscriptionModel,
+        },
+        { provide: getModelToken(User.name), useValue: mockUserModel },
+        { provide: getModelToken(SMS.name), useValue: emptyModel },
+        {
+          provide: getModelToken(PolarWebhookPayload.name),
+          useValue: emptyModel,
+        },
+        { provide: getModelToken(CheckoutSession.name), useValue: emptyModel },
+        { provide: BillingNotificationsService, useValue: {} },
+        { provide: UsersService, useValue: mockUsersService },
+        { provide: AnalyticsService, useValue: mockAnalyticsService },
+      ],
+    }).compile()
+
+    service = module.get<BillingService>(BillingService)
+
+    jest.clearAllMocks()
+    mockPlanModel.findOne.mockResolvedValue(proPlan)
+    mockSubscriptionModel.updateMany.mockResolvedValue({ modifiedCount: 0 })
+    mockSubscriptionModel.updateOne.mockResolvedValue({ upsertedCount: 1 })
+    mockUserModel.findById.mockResolvedValue({
+      _id: userId,
+      email: 'ada@example.com',
+    })
+    mockUsersService.markMilestone.mockResolvedValue(true)
+  })
+
+  it('reports the sale the first time an account pays', async () => {
+    await service.switchPlan(activePayment)
+
+    expect(mockUsersService.markMilestone).toHaveBeenCalledWith(
+      userId,
+      'firstPaidAt',
+    )
+    expect(mockAnalyticsService.purchase).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'ada@example.com' }),
+      expect.objectContaining({
+        amount: 1200,
+        currency: 'usd',
+        plan: 'pro',
+        subscriptionId: 'sub_1',
+      }),
+    )
+  })
+
+  it('reports nothing on a renewal, an upgrade, or a re-subscribe', async () => {
+    // The milestone is already stamped, so every later payment is a no-op
+    // regardless of whether the subscription row was created or updated.
+    mockUsersService.markMilestone.mockResolvedValue(false)
+
+    mockSubscriptionModel.updateOne.mockResolvedValue({ upsertedCount: 0 })
+    await service.switchPlan(activePayment)
+
+    // An upgrade creates a second {user, plan} row, which upsertedCount would
+    // have treated as a brand new sale.
+    mockSubscriptionModel.updateOne.mockResolvedValue({ upsertedCount: 1 })
+    await service.switchPlan({ ...activePayment, newPlanName: 'scale' })
+
+    expect(mockAnalyticsService.purchase).not.toHaveBeenCalled()
+  })
+
+  it('ignores a subscription that is not active yet', async () => {
+    // subscription.created can arrive before the card is charged.
+    await service.switchPlan({ ...activePayment, status: 'incomplete' })
+    await service.switchPlan({ ...activePayment, status: 'trialing' })
+
+    expect(mockUsersService.markMilestone).not.toHaveBeenCalled()
+    expect(mockAnalyticsService.purchase).not.toHaveBeenCalled()
+  })
+
+  it('ignores an event that carries no money', async () => {
+    await service.switchPlan({ ...activePayment, amount: undefined })
+    await service.switchPlan({ ...activePayment, amount: 0 })
+
+    expect(mockUsersService.markMilestone).not.toHaveBeenCalled()
+    expect(mockAnalyticsService.purchase).not.toHaveBeenCalled()
+  })
+
+  it('still switches the plan when reporting fails', async () => {
+    mockUsersService.markMilestone.mockRejectedValue(new Error('mongo down'))
+
+    await expect(service.switchPlan(activePayment)).resolves.toEqual({
+      success: true,
+      plan: 'pro',
+    })
   })
 })

--- a/api/src/billing/billing.service.ts
+++ b/api/src/billing/billing.service.ts
@@ -13,6 +13,8 @@ import {
 } from './schemas/subscription.schema'
 import { Polar } from '@polar-sh/sdk'
 import { User, UserDocument } from '../users/schemas/user.schema'
+import { UsersService } from '../users/users.service'
+import { AnalyticsService } from '../analytics/analytics.service'
 import { CheckoutResponseDTO, PlanDTO } from './billing.dto'
 import { SMSDocument } from '../gateway/schemas/sms.schema'
 import { SMS } from '../gateway/schemas/sms.schema'
@@ -45,6 +47,8 @@ export class BillingService {
     @InjectModel(CheckoutSession.name)
     private checkoutSessionModel: Model<CheckoutSessionDocument>,
     private readonly billingNotifications: BillingNotificationsService,
+    private readonly usersService: UsersService,
+    private readonly analyticsService: AnalyticsService,
   ) {
     this.polarApi = new Polar({
       accessToken: process.env.POLAR_ACCESS_TOKEN ?? '',
@@ -325,6 +329,10 @@ export class BillingService {
         customerIpAddress: req.ip,
         metadata: {
           userId: user._id?.toString(),
+          ...(user.signupSource && { signupSource: user.signupSource }),
+          ...(user.attribution?.first?.campaign && {
+            utmCampaign: user.attribution.first.campaign,
+          }),
         },
         externalCustomerId: user._id?.toString(),
       }
@@ -344,6 +352,11 @@ export class BillingService {
       }
 
       const checkout = await this.polarApi.checkouts.create(checkoutOptions)
+
+      this.analyticsService.checkoutStarted(user as any, payload.planName, {
+        ip: req.ip,
+        userAgent: req.headers?.['user-agent'],
+      })
 
       this.checkoutSessionModel
         .updateOne(
@@ -855,7 +868,66 @@ export class BillingService {
       `Updated or created subscription: ${updateResult.upsertedCount > 0 ? 'Created' : 'Updated'}`,
     )
 
+    await this.reportFirstPayment({
+      userId,
+      plan: plan.name,
+      status,
+      amount,
+      currency,
+      polarSubscriptionId,
+    })
+
     return { success: true, plan: plan.name }
+  }
+
+  /**
+   * Reports a sale to the ad platforms the first time an account actually pays.
+   * The milestone write is the only gate, which makes renewals, upgrades and
+   * re-subscribes idempotent: whichever webhook arrives first wins, and every
+   * later one is a no-op.
+   *
+   * subscription.created can arrive before payment succeeds, so a status that
+   * is not active is ignored rather than reported as revenue.
+   */
+  private async reportFirstPayment({
+    userId,
+    plan,
+    status,
+    amount,
+    currency,
+    polarSubscriptionId,
+  }: {
+    userId: string
+    plan?: string
+    status?: string
+    amount?: number
+    currency?: string
+    polarSubscriptionId?: string
+  }) {
+    if (status !== 'active') return
+    if (typeof amount !== 'number' || amount <= 0) return
+
+    try {
+      const isFirstPayment = await this.usersService.markMilestone(
+        userId,
+        'firstPaidAt',
+      )
+      if (!isFirstPayment) return
+
+      // Loaded only now, and only once per account, because the conversion
+      // event needs the email to hash for matching.
+      const user = await this.userModel.findById(userId)
+      if (!user) return
+
+      this.analyticsService.purchase(user as any, {
+        amount,
+        currency,
+        plan,
+        subscriptionId: polarSubscriptionId,
+      })
+    } catch (error) {
+      console.error('Failed to report first payment', error)
+    }
   }
 
   async cancelSubscription({

--- a/api/src/gateway/gateway.service.spec.ts
+++ b/api/src/gateway/gateway.service.spec.ts
@@ -10,6 +10,7 @@ import { AuthService } from '../auth/auth.service'
 import { WebhookService } from '../webhook/webhook.service'
 import { BillingService } from '../billing/billing.service'
 import { SmsQueueService } from './queue/sms-queue.service'
+import { UsersService } from '../users/users.service'
 import { Model, Types } from 'mongoose'
 import { ConfigModule } from '@nestjs/config'
 import { HttpException, HttpStatus } from '@nestjs/common'
@@ -100,6 +101,10 @@ describe('GatewayService', () => {
     removeJobs: jest.fn(),
   }
 
+  const mockUsersService = {
+    markMilestone: jest.fn().mockResolvedValue(false),
+  }
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -135,6 +140,10 @@ describe('GatewayService', () => {
         {
           provide: SmsQueueService,
           useValue: mockSmsQueueService,
+        },
+        {
+          provide: UsersService,
+          useValue: mockUsersService,
         },
       ],
       imports: [ConfigModule],

--- a/api/src/gateway/gateway.service.ts
+++ b/api/src/gateway/gateway.service.ts
@@ -23,6 +23,7 @@ import { BatchResponse, Message } from 'firebase-admin/messaging'
 import { WebhookEvent } from '../webhook/webhook-event.enum'
 import { WebhookService } from '../webhook/webhook.service'
 import { BillingService } from '../billing/billing.service'
+import { UsersService } from '../users/users.service'
 import { SmsQueueService } from './queue/sms-queue.service'
 import { escapeRegExp } from '../common/escape-regexp'
 import { normalizeOsFields } from './os-version'
@@ -38,6 +39,11 @@ import {
 import { DispatchPlan } from './queue/dispatch-pacing'
 import { Job } from 'bull'
 
+// device.user is a ref, so it is an ObjectId unless the query populated it.
+function userIdOf(user: any) {
+  return user?._id ?? user
+}
+
 @Injectable()
 export class GatewayService {
   constructor(
@@ -50,6 +56,7 @@ export class GatewayService {
     private webhookService: WebhookService,
     private billingService: BillingService,
     private smsQueueService: SmsQueueService,
+    private usersService: UsersService,
   ) {}
 
   // Blocks creating or re-enabling a device when the user's plan device limit
@@ -167,7 +174,15 @@ export class GatewayService {
         deviceData.isDefault = true
       }
 
-      return await this.deviceModel.create(deviceData)
+      const createdDevice = await this.deviceModel.create(deviceData)
+
+      // The app re-registers on every launch, so this has to be idempotent.
+      // markMilestone's $exists filter makes it a no-op after the first time.
+      this.usersService
+        .markMilestone(user._id, 'firstDeviceAt')
+        .catch(() => undefined)
+
+      return createdDevice
     }
   }
 
@@ -660,6 +675,14 @@ export class GatewayService {
           console.log(e)
         })
 
+      // sentSMSCount is read before the increment above, so a zero here means
+      // this send is the account's first.
+      if (device.sentSMSCount === 0 && response.successCount > 0) {
+        this.usersService
+          .markMilestone(userIdOf(device.user), 'firstSmsAt')
+          .catch(() => undefined)
+      }
+
       this.smsBatchModel
         .findByIdAndUpdate(smsBatch._id, {
           $set: { status: 'completed' },
@@ -994,6 +1017,10 @@ export class GatewayService {
       )
     }
 
+    // fcmMessagesBatches holds one message per entry, so anything inside this
+    // loop runs once per recipient. The milestone is tracked outside it.
+    let isFirstSmsForAccount = device.sentSMSCount === 0
+
     for (const batch of fcmMessagesBatches) {
       try {
         const response = skipped
@@ -1012,6 +1039,13 @@ export class GatewayService {
             console.log('Failed to update sentSMSCount')
             console.log(e)
           })
+
+        if (isFirstSmsForAccount && response.successCount > 0) {
+          isFirstSmsForAccount = false
+          this.usersService
+            .markMilestone(userIdOf(device.user), 'firstSmsAt')
+            .catch(() => undefined)
+        }
 
         this.smsBatchModel
           .findByIdAndUpdate(smsBatch._id, {

--- a/api/src/gateway/queue/sms-queue.processor.spec.ts
+++ b/api/src/gateway/queue/sms-queue.processor.spec.ts
@@ -64,6 +64,7 @@ describe('SmsQueueProcessor.handleSendSms', () => {
     findByIdAndUpdate: jest.fn(),
   }
   const mockWebhookService = { deliverNotification: jest.fn() }
+  const mockUsersService = { markMilestone: jest.fn() }
 
   let processor: SmsQueueProcessor
 
@@ -87,12 +88,14 @@ describe('SmsQueueProcessor.handleSendSms', () => {
     })
     mockSmsModel.updateMany.mockResolvedValue({ modifiedCount: 1 })
     mockSmsModel.find.mockResolvedValue([])
+    mockUsersService.markMilestone.mockResolvedValue(false)
 
     processor = new SmsQueueProcessor(
       mockDeviceModel as any,
       mockSmsModel as any,
       mockSmsBatchModel as any,
       mockWebhookService as any,
+      mockUsersService as any,
     )
   })
 

--- a/api/src/gateway/queue/sms-queue.processor.ts
+++ b/api/src/gateway/queue/sms-queue.processor.ts
@@ -6,6 +6,7 @@ import * as firebaseAdmin from 'firebase-admin'
 import { Device } from '../schemas/device.schema'
 import { SMS } from '../schemas/sms.schema'
 import { SMSBatch } from '../schemas/sms-batch.schema'
+import { UsersService } from '../../users/users.service'
 import { WebhookService } from 'src/webhook/webhook.service'
 import { WebhookEvent } from 'src/webhook/webhook-event.enum'
 import { Logger } from '@nestjs/common'
@@ -41,7 +42,7 @@ const FCM_ACTIONABLE_MESSAGE =
 
 function getFcmErrorMessage(error: { code?: string; message?: string } | null | undefined): string {
   const rawPart = `FCM_DELIVERY_FAILED: ${error?.message || 'FCM delivery failed'}`
-  return `${rawPart} — ${FCM_ACTIONABLE_MESSAGE}`
+  return `${rawPart}. ${FCM_ACTIONABLE_MESSAGE}`
 }
 
 // A paced batch is still 'processing' until every wave has been handed to FCM
@@ -68,6 +69,7 @@ export class SmsQueueProcessor {
     @InjectModel(SMS.name) private smsModel: Model<SMS>,
     @InjectModel(SMSBatch.name) private smsBatchModel: Model<SMSBatch>,
     private webhookService: WebhookService,
+    private usersService: UsersService,
   ) {}
 
   @Process({
@@ -211,6 +213,14 @@ export class SmsQueueProcessor {
           $inc: { sentSMSCount: response.successCount },
         })
         .exec()
+
+      // device was loaded before the increment, so zero means this job carried
+      // the account's first message.
+      if (device?.user && device.sentSMSCount === 0 && response.successCount > 0) {
+        this.usersService
+          .markMilestone((device.user as any)?._id ?? device.user, 'firstSmsAt')
+          .catch(() => undefined)
+      }
 
       // Update batch status
       const smsBatch = await this.smsBatchModel.findByIdAndUpdate(

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -81,6 +81,10 @@ async function bootstrap() {
     express.raw({ type: 'application/json' }),
   )
   app.useBodyParser('json', { limit: '2mb' });
+  // The app runs behind a reverse proxy, so without this req.ip is the proxy's
+  // loopback address for every request. That makes rate limiting see one client
+  // and gives conversion reporting a single useless IP for everyone.
+  app.set('trust proxy', 1)
   app.enableCors()
   await app.listen(PORT)
 }

--- a/api/src/users/attribution.spec.ts
+++ b/api/src/users/attribution.spec.ts
@@ -1,0 +1,200 @@
+import {
+  classifyDevice,
+  normalizeReferrer,
+  normalizeSignupSource,
+  sanitizeAttribution,
+} from './attribution'
+
+describe('normalizeSignupSource', () => {
+  it('falls back to direct with nothing to go on', () => {
+    expect(normalizeSignupSource(undefined)).toBe('direct')
+    expect(normalizeSignupSource(null)).toBe('direct')
+    expect(normalizeSignupSource({})).toBe('direct')
+    expect(normalizeSignupSource({ first: { landingPath: '/' } })).toBe('direct')
+  })
+
+  it('prefers an explicit utm_source', () => {
+    expect(
+      normalizeSignupSource({
+        first: { source: 'Meta', fbclid: 'abc', referrer: 'reddit.com' },
+      }),
+    ).toBe('meta')
+  })
+
+  it('uses a ref parameter when there is no utm_source', () => {
+    expect(normalizeSignupSource({ first: { ref: 'reddit-selfhosted' } })).toBe(
+      'reddit-selfhosted',
+    )
+  })
+
+  it('reads the channel from a click id when nothing else is present', () => {
+    expect(normalizeSignupSource({ first: { gclid: 'xyz' } })).toBe('google-ads')
+    expect(normalizeSignupSource({ first: { fbclid: 'xyz' } })).toBe('meta')
+  })
+
+  it('credits first touch, not last', () => {
+    expect(
+      normalizeSignupSource({
+        first: { source: 'meta' },
+        last: { source: 'google' },
+      }),
+    ).toBe('meta')
+  })
+
+  it('falls back to last touch when first touch was never recorded', () => {
+    expect(normalizeSignupSource({ last: { source: 'reddit' } })).toBe('reddit')
+  })
+})
+
+describe('normalizeReferrer', () => {
+  const cases: Array<[string, string]> = [
+    ['facebook.com', 'meta'],
+    ['m.facebook.com', 'meta'],
+    ['l.facebook.com', 'meta'],
+    ['lm.facebook.com', 'meta'],
+    ['instagram.com', 'meta'],
+    ['l.instagram.com', 'meta'],
+    ['www.google.com', 'google'],
+    ['google.co.uk', 'google'],
+    ['bing.com', 'bing'],
+    ['duckduckgo.com', 'duckduckgo'],
+    ['chatgpt.com', 'chatgpt'],
+    ['chat.openai.com', 'chatgpt'],
+    ['gemini.google.com', 'gemini'],
+    ['claude.ai', 'claude'],
+    ['perplexity.ai', 'perplexity'],
+    ['copilot.microsoft.com', 'copilot'],
+    ['meta.ai', 'meta-ai'],
+    ['github.com', 'github'],
+    ['reddit.com', 'reddit'],
+    ['old.reddit.com', 'reddit'],
+    ['t.co', 'x'],
+    ['x.com', 'x'],
+    ['twitter.com', 'x'],
+    ['linkedin.com', 'linkedin'],
+    ['lnkd.in', 'linkedin'],
+    ['youtube.com', 'youtube'],
+    ['youtu.be', 'youtube'],
+    ['news.ycombinator.com', 'hackernews'],
+    ['producthunt.com', 'producthunt'],
+  ]
+
+  it.each(cases)('maps %s to %s', (host, expected) => {
+    expect(normalizeReferrer(host)).toBe(expected)
+  })
+
+  it('does not let a search engine domain swallow its assistant', () => {
+    expect(normalizeReferrer('gemini.google.com')).toBe('gemini')
+    expect(normalizeReferrer('www.google.com')).toBe('google')
+  })
+
+  it('keeps an unrecognised host so a new channel is still visible', () => {
+    expect(normalizeReferrer('some-blog.example')).toBe('some-blog.example')
+  })
+
+  it('is case and www insensitive', () => {
+    expect(normalizeReferrer('WWW.Reddit.com')).toBe('reddit')
+  })
+})
+
+describe('classifyDevice', () => {
+  it('reads the device class from the user agent', () => {
+    expect(
+      classifyDevice(
+        'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36',
+      ),
+    ).toBe('android')
+    expect(
+      classifyDevice('Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)'),
+    ).toBe('ios')
+    expect(
+      classifyDevice('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)'),
+    ).toBe('desktop')
+    expect(classifyDevice('Mozilla/5.0 (Windows NT 10.0; Win64; x64)')).toBe(
+      'desktop',
+    )
+  })
+
+  it('returns other rather than guessing', () => {
+    expect(classifyDevice(undefined)).toBe('other')
+    expect(classifyDevice('')).toBe('other')
+    expect(classifyDevice('curl/8.4.0')).toBe('other')
+  })
+})
+
+describe('sanitizeAttribution', () => {
+  it('rejects anything that is not an object of touches', () => {
+    expect(sanitizeAttribution(undefined)).toBeUndefined()
+    expect(sanitizeAttribution(null)).toBeUndefined()
+    expect(sanitizeAttribution('meta')).toBeUndefined()
+    expect(sanitizeAttribution(42)).toBeUndefined()
+    expect(sanitizeAttribution([{ source: 'meta' }])).toBeUndefined()
+    expect(sanitizeAttribution({})).toBeUndefined()
+    expect(sanitizeAttribution({ first: 'meta' })).toBeUndefined()
+  })
+
+  it('keeps only known fields', () => {
+    const result = sanitizeAttribution({
+      first: { source: 'meta', campaign: 'c1', evil: 'drop me' },
+      last: { source: 'reddit' },
+      fbp: 'fb.1.123.456',
+      somethingElse: 'drop me',
+    })
+
+    expect(result?.first).toEqual({ source: 'meta', campaign: 'c1' })
+    expect(result?.last).toEqual({ source: 'reddit' })
+    expect(result?.fbp).toBe('fb.1.123.456')
+    expect(result as any).not.toHaveProperty('somethingElse')
+  })
+
+  it('drops non-string values instead of storing them', () => {
+    const result = sanitizeAttribution({
+      first: { source: { $ne: null }, campaign: 42, ref: ['a'] },
+    })
+    expect(result).toBeUndefined()
+  })
+
+  it('caps a long field at 200 characters', () => {
+    const result = sanitizeAttribution({
+      first: { campaign: 'x'.repeat(5000) },
+    })
+    expect(result?.first?.campaign).toHaveLength(200)
+  })
+
+  it('ignores a huge object rather than walking all of it', () => {
+    const first: Record<string, string> = { source: 'meta' }
+    for (let i = 0; i < 5000; i++) first[`junk${i}`] = 'x'
+
+    const result = sanitizeAttribution({ first })
+    expect(Object.keys(result?.first ?? {}).length).toBeLessThanOrEqual(20)
+  })
+
+  it('does not read inherited or prototype keys', () => {
+    const first = Object.create({ source: 'inherited' })
+    first.campaign = 'c1'
+
+    const result = sanitizeAttribution({ first })
+    expect(result?.first?.source).toBeUndefined()
+    expect(result?.first?.campaign).toBe('c1')
+
+    const polluted = JSON.parse('{"first":{"__proto__":{"source":"evil"}}}')
+    expect(sanitizeAttribution(polluted)).toBeUndefined()
+    expect(({} as any).source).toBeUndefined()
+  })
+
+  it('parses a valid timestamp and drops an invalid one', () => {
+    expect(
+      sanitizeAttribution({ first: { at: '2026-09-11T10:00:00.000Z' } })?.first
+        ?.at,
+    ).toEqual(new Date('2026-09-11T10:00:00.000Z'))
+
+    expect(
+      sanitizeAttribution({ first: { source: 'meta', at: 'never' } })?.first?.at,
+    ).toBeUndefined()
+  })
+
+  it('stamps when it was captured', () => {
+    const result = sanitizeAttribution({ first: { source: 'meta' } })
+    expect(result?.capturedAt).toBeInstanceOf(Date)
+  })
+})

--- a/api/src/users/attribution.ts
+++ b/api/src/users/attribution.ts
@@ -1,0 +1,168 @@
+// Turns the raw attribution blob the browser sends into the fields an
+// acquisition report reads. Pure and defensive: the payload is attacker
+// controlled and the API has no global ValidationPipe, so this is the only gate
+// between the request body and the database.
+
+export type AttributionTouchInput = {
+  source?: string
+  medium?: string
+  campaign?: string
+  content?: string
+  term?: string
+  ref?: string
+  referrer?: string
+  landingPath?: string
+  fbclid?: string
+  gclid?: string
+  at?: string | Date
+}
+
+export type AttributionInput = {
+  first?: AttributionTouchInput
+  last?: AttributionTouchInput
+  fbp?: string
+  capturedAt?: Date
+}
+
+const TOUCH_STRING_FIELDS = [
+  'source',
+  'medium',
+  'campaign',
+  'content',
+  'term',
+  'ref',
+  'referrer',
+  'landingPath',
+  'fbclid',
+  'gclid',
+] as const
+
+const MAX_FIELD_LENGTH = 200
+const MAX_KEYS = 20
+
+// Referrer hosts worth naming. Anything unlisted falls through to its bare
+// hostname, which keeps a new channel visible in reports without a code change.
+// Order matters. The assistants come first because several of them sit on a
+// search engine's domain: gemini.google.com would otherwise be counted as
+// Google search and quietly understate AI referrals.
+const REFERRER_SOURCES: Array<[RegExp, string]> = [
+  [/(^|\.)chatgpt\.com$/, 'chatgpt'],
+  [/(^|\.)openai\.com$/, 'chatgpt'],
+  [/(^|\.)gemini\.google\.com$/, 'gemini'],
+  [/(^|\.)aistudio\.google\.com$/, 'gemini'],
+  [/(^|\.)claude\.ai$/, 'claude'],
+  [/(^|\.)perplexity\.ai$/, 'perplexity'],
+  [/(^|\.)copilot\.microsoft\.com$/, 'copilot'],
+  [/(^|\.)meta\.ai$/, 'meta-ai'],
+  [/(^|\.)(facebook|instagram)\.com$/, 'meta'],
+  [/(^|\.)messenger\.com$/, 'meta'],
+  [/(^|\.)google\./, 'google'],
+  [/(^|\.)bing\.com$/, 'bing'],
+  [/(^|\.)duckduckgo\.com$/, 'duckduckgo'],
+  [/(^|\.)ecosia\.org$/, 'ecosia'],
+  [/(^|\.)yandex\./, 'yandex'],
+  [/(^|\.)github\.com$/, 'github'],
+  [/(^|\.)reddit\.com$/, 'reddit'],
+  [/(^|\.)(x|twitter)\.com$/, 'x'],
+  [/^t\.co$/, 'x'],
+  [/(^|\.)linkedin\.com$/, 'linkedin'],
+  [/^lnkd\.in$/, 'linkedin'],
+  [/(^|\.)(youtube\.com|youtu\.be)$/, 'youtube'],
+  [/(^|\.)news\.ycombinator\.com$/, 'hackernews'],
+  [/(^|\.)producthunt\.com$/, 'producthunt'],
+  [/(^|\.)stackoverflow\.com$/, 'stackoverflow'],
+]
+
+function cleanString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim().slice(0, MAX_FIELD_LENGTH)
+  return trimmed || undefined
+}
+
+function sanitizeTouch(value: unknown): AttributionTouchInput | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined
+  }
+  // Own keys only, so a prototype-polluting payload contributes nothing, and a
+  // capped count so a huge object cannot be walked.
+  const keys = Object.keys(value as Record<string, unknown>).slice(0, MAX_KEYS)
+  const input = value as Record<string, unknown>
+
+  const touch: Record<string, unknown> = {}
+  for (const key of keys) {
+    if ((TOUCH_STRING_FIELDS as readonly string[]).includes(key)) {
+      const cleaned = cleanString(input[key])
+      if (cleaned) touch[key] = cleaned
+    } else if (key === 'at') {
+      const parsed = new Date(input[key] as string)
+      if (!Number.isNaN(parsed.getTime())) touch.at = parsed
+    }
+  }
+
+  return Object.keys(touch).length ? (touch as AttributionTouchInput) : undefined
+}
+
+export function sanitizeAttribution(value: unknown): AttributionInput | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined
+  }
+  const input = value as Record<string, unknown>
+
+  const first = sanitizeTouch(input.first)
+  const last = sanitizeTouch(input.last)
+  const fbp = cleanString(input.fbp)
+
+  if (!first && !last && !fbp) return undefined
+
+  return {
+    ...(first && { first }),
+    ...(last && { last }),
+    ...(fbp && { fbp }),
+    capturedAt: new Date(),
+  }
+}
+
+export function normalizeReferrer(referrer: string): string {
+  const host = referrer.trim().toLowerCase().replace(/^www\./, '')
+  if (!host) return ''
+  for (const [pattern, name] of REFERRER_SOURCES) {
+    if (pattern.test(host)) return name
+  }
+  return host
+}
+
+// First touch, not last: the channel that introduced someone to textbee is the
+// one that earned the signup, even if they came back through a search later.
+export function normalizeSignupSource(
+  attribution?: AttributionInput | null,
+): string {
+  const first = attribution?.first ?? attribution?.last
+  if (!first) return 'direct'
+
+  const source = cleanString(first.source)
+  if (source) return source.toLowerCase()
+
+  const ref = cleanString(first.ref)
+  if (ref) return ref.toLowerCase()
+
+  if (cleanString(first.gclid)) return 'google-ads'
+  if (cleanString(first.fbclid)) return 'meta'
+
+  const referrer = cleanString(first.referrer)
+  if (referrer) return normalizeReferrer(referrer)
+
+  return 'direct'
+}
+
+// The device an advert was seen on, which is not proof of what hardware the
+// person owns. Reported against milestones.firstDeviceAt rather than used to
+// exclude anyone.
+export function classifyDevice(userAgent?: string): string {
+  if (!userAgent) return 'other'
+  const ua = userAgent.toLowerCase()
+  if (ua.includes('android')) return 'android'
+  if (/iphone|ipad|ipod/.test(ua)) return 'ios'
+  if (ua.includes('mobile')) return 'other'
+  if (/windows|macintosh|mac os x|linux|cros/.test(ua)) return 'desktop'
+  return 'other'
+}

--- a/api/src/users/schemas/user.schema.ts
+++ b/api/src/users/schemas/user.schema.ts
@@ -4,6 +4,85 @@ import { UserRole } from '../user-roles.enum'
 
 export type UserDocument = User & Document
 
+// One visit that brought someone to the site. Stored as captured so a later
+// report can group by whichever field turns out to matter, rather than only by
+// the normalised signupSource.
+@Schema({ _id: false })
+export class AttributionTouch {
+  @Prop({ type: String })
+  source?: string
+
+  @Prop({ type: String })
+  medium?: string
+
+  @Prop({ type: String })
+  campaign?: string
+
+  @Prop({ type: String })
+  content?: string
+
+  @Prop({ type: String })
+  term?: string
+
+  @Prop({ type: String })
+  ref?: string
+
+  @Prop({ type: String })
+  referrer?: string
+
+  @Prop({ type: String })
+  landingPath?: string
+
+  @Prop({ type: String })
+  fbclid?: string
+
+  @Prop({ type: String })
+  gclid?: string
+
+  @Prop({ type: Date })
+  at?: Date
+}
+
+const AttributionTouchSchema = SchemaFactory.createForClass(AttributionTouch)
+
+@Schema({ _id: false })
+export class Attribution {
+  @Prop({ type: AttributionTouchSchema })
+  first?: AttributionTouch
+
+  @Prop({ type: AttributionTouchSchema })
+  last?: AttributionTouch
+
+  // Meta's browser cookie, needed to match a server-side conversion event back
+  // to the ad click.
+  @Prop({ type: String })
+  fbp?: string
+
+  @Prop({ type: Date })
+  capturedAt?: Date
+}
+
+const AttributionSchema = SchemaFactory.createForClass(Attribution)
+
+// First time the account reached each step. Written once and never updated, so
+// a funnel report is a query over users alone rather than a scan of sends.
+@Schema({ _id: false })
+export class UserMilestones {
+  @Prop({ type: Date })
+  firstDeviceAt?: Date
+
+  @Prop({ type: Date })
+  firstApiKeyAt?: Date
+
+  @Prop({ type: Date })
+  firstSmsAt?: Date
+
+  @Prop({ type: Date })
+  firstPaidAt?: Date
+}
+
+const UserMilestonesSchema = SchemaFactory.createForClass(UserMilestones)
+
 @Schema({ timestamps: true })
 export class User {
   _id?: Types.ObjectId
@@ -48,6 +127,25 @@ export class User {
   @Prop({ type: Object })
   meta: Object
 
+  // Normalised acquisition channel, for example meta, reddit, google, direct.
+  @Prop({ type: String, index: true })
+  signupSource?: string
+
+  // Device class the account was created on: android, ios, desktop or other.
+  // An advert seen on an iPhone can still lead to a gateway on a spare Android,
+  // so this is compared against milestones.firstDeviceAt rather than assumed.
+  @Prop({ type: String })
+  signupDevice?: string
+
+  @Prop({ type: AttributionSchema })
+  attribution?: Attribution
+
+  @Prop({ type: Boolean, default: false })
+  marketingOptIn?: boolean
+
+  @Prop({ type: UserMilestonesSchema, default: () => ({}) })
+  milestones?: UserMilestones
+
   @Prop({
     type: {
       completedAt: { type: Date },
@@ -64,3 +162,6 @@ export class User {
 }
 
 export const UserSchema = SchemaFactory.createForClass(User)
+
+// Acquisition reports read by channel over a date window.
+UserSchema.index({ signupSource: 1, createdAt: -1 })

--- a/api/src/users/users.service.spec.ts
+++ b/api/src/users/users.service.spec.ts
@@ -1,0 +1,102 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { getModelToken } from '@nestjs/mongoose'
+import { UsersService } from './users.service'
+import { User } from './schemas/user.schema'
+
+describe('UsersService - signup attribution', () => {
+  let service: UsersService
+  const saved: any[] = []
+
+  // A constructor-shaped mock, because create() does `new this.userModel(...)`.
+  function UserModel(this: any, doc: any) {
+    Object.assign(this, doc)
+    this.save = jest.fn().mockResolvedValue(this)
+    saved.push(this)
+  }
+  ;(UserModel as any).findOne = jest.fn()
+  ;(UserModel as any).updateOne = jest.fn()
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UsersService,
+        { provide: getModelToken(User.name), useValue: UserModel },
+      ],
+    }).compile()
+
+    service = module.get<UsersService>(UsersService)
+    saved.length = 0
+    jest.clearAllMocks()
+    ;(UserModel as any).findOne.mockResolvedValue(null)
+  })
+
+  it('records the normalised source and device at signup', async () => {
+    await service.create({
+      name: 'Ada',
+      email: 'ada@example.com',
+      attribution: { first: { source: 'meta', campaign: 'c1' } },
+      userAgent: 'Mozilla/5.0 (Linux; Android 14; Pixel 8)',
+    })
+
+    expect(saved[0]).toMatchObject({
+      signupSource: 'meta',
+      signupDevice: 'android',
+      attribution: { first: { source: 'meta', campaign: 'c1' } },
+    })
+  })
+
+  it('falls back to direct rather than leaving the source blank', async () => {
+    await service.create({ name: 'Ada', email: 'ada@example.com' })
+
+    expect(saved[0].signupSource).toBe('direct')
+    expect(saved[0].signupDevice).toBe('other')
+  })
+
+  it('defaults the marketing opt in to false', async () => {
+    await service.create({ name: 'Ada', email: 'ada@example.com' })
+    expect(saved[0].marketingOptIn).toBe(false)
+
+    await service.create({
+      name: 'Ada',
+      email: 'ada@example.com',
+      marketingOptIn: true,
+    })
+    expect(saved[1].marketingOptIn).toBe(true)
+  })
+})
+
+describe('UsersService - markMilestone', () => {
+  let service: UsersService
+  const userModel = { updateOne: jest.fn() }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UsersService,
+        { provide: getModelToken(User.name), useValue: userModel },
+      ],
+    }).compile()
+
+    service = module.get<UsersService>(UsersService)
+    jest.clearAllMocks()
+  })
+
+  it('only writes when the milestone is not already set', async () => {
+    userModel.updateOne.mockResolvedValue({ modifiedCount: 1 })
+
+    await service.markMilestone('user-1', 'firstSmsAt')
+
+    expect(userModel.updateOne).toHaveBeenCalledWith(
+      { _id: 'user-1', 'milestones.firstSmsAt': { $exists: false } },
+      { $set: { 'milestones.firstSmsAt': expect.any(Date) } },
+    )
+  })
+
+  it('reports true once and false afterwards, so callers fire one event', async () => {
+    userModel.updateOne.mockResolvedValueOnce({ modifiedCount: 1 })
+    expect(await service.markMilestone('user-1', 'firstPaidAt')).toBe(true)
+
+    userModel.updateOne.mockResolvedValueOnce({ modifiedCount: 0 })
+    expect(await service.markMilestone('user-1', 'firstPaidAt')).toBe(false)
+  })
+})

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -1,12 +1,23 @@
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common'
 import { InjectModel } from '@nestjs/mongoose'
 import { User, UserDocument } from './schemas/user.schema'
-import { Model } from 'mongoose'
+import { Model, Types } from 'mongoose'
 import { UpdateOnboardingDTO } from '../auth/auth.dto'
 import {
   ONBOARDING_OPTIONAL_STEP_IDS,
   ONBOARDING_STEP_ORDER,
 } from './onboarding.constants'
+import {
+  AttributionInput,
+  classifyDevice,
+  normalizeSignupSource,
+} from './attribution'
+
+export type UserMilestoneField =
+  | 'firstDeviceAt'
+  | 'firstApiKeyAt'
+  | 'firstSmsAt'
+  | 'firstPaidAt'
 
 @Injectable()
 export class UsersService {
@@ -32,11 +43,17 @@ export class UsersService {
     email,
     password,
     phone,
+    marketingOptIn,
+    attribution,
+    userAgent,
   }: {
     name: string
     email: string
     password?: string
     phone?: string
+    marketingOptIn?: boolean
+    attribution?: AttributionInput
+    userAgent?: string
   }) {
     if (await this.findOne({ email })) {
       throw new HttpException(
@@ -52,8 +69,30 @@ export class UsersService {
       email,
       password,
       phone,
+      marketingOptIn: marketingOptIn ?? false,
+      attribution,
+      signupSource: normalizeSignupSource(attribution),
+      signupDevice: classifyDevice(userAgent),
     })
     return await newUser.save()
+  }
+
+  /**
+   * Stamps a milestone the first time it happens and never again. The
+   * $exists filter does that in one write, so callers can fire a conversion
+   * event on the returned true without reading the user first, and a repeated
+   * call (every app launch re-registers a device) is a no-op.
+   */
+  async markMilestone(
+    userId: string | Types.ObjectId,
+    field: UserMilestoneField,
+  ): Promise<boolean> {
+    const path = `milestones.${field}`
+    const result = await this.userModel.updateOne(
+      { _id: userId, [path]: { $exists: false } },
+      { $set: { [path]: new Date() } },
+    )
+    return result.modifiedCount === 1
   }
 
   async updateProfile(

--- a/web/.env.example
+++ b/web/.env.example
@@ -2,7 +2,6 @@ NEXT_PUBLIC_SITE_URL=http://localhost:3000
 NEXT_PUBLIC_API_BASE_URL=http://localhost:3001/api/v1
 NEXT_PUBLIC_LATEST_APP_VERSION_CODE=17
 NEXT_PUBLIC_GOOGLE_CLIENT_ID=
-NEXT_PUBLIC_TAWKTO_EMBED_URL=
 
 # Used by NextAuth (next-auth v4) to sign/verify the session JWT. Must match
 # the value read by proxy.ts (process.env.NEXTAUTH_SECRET).
@@ -21,3 +20,25 @@ NEXT_PUBLIC_TURNSTILE_SITE_KEY=1x00000000000000000000AA #test
 # Recipient count above which the bulk send wizard warns about how long the
 # send will take. Advisory only, nothing is blocked. Defaults to 500.
 NEXT_PUBLIC_BULK_RECIPIENT_WARN_THRESHOLD=500
+
+# Analytics and ad-platform tracking.
+# Leave NEXT_PUBLIC_ANALYTICS_PROVIDERS unset to load no third-party scripts.
+# Comma separated, any of: ga, clarity, meta.
+# A provider listed without its id below is skipped.
+NEXT_PUBLIC_ANALYTICS_PROVIDERS=
+NEXT_PUBLIC_GA_MEASUREMENT_ID=
+NEXT_PUBLIC_CLARITY_PROJECT_ID=
+NEXT_PUBLIC_META_PIXEL_ID=
+
+# Domain for the first-party attribution cookie, for example .example.com when
+# the marketing site and the dashboard sit on different subdomains. Leave unset
+# for a single-domain install, which keeps the cookie host-only.
+NEXT_PUBLIC_ATTRIBUTION_COOKIE_DOMAIN=
+
+# Support chat widget. Unset means no widget script loads.
+NEXT_PUBLIC_SUPPORT_HQ_PROJECT_ID=
+NEXT_PUBLIC_SUPPORT_HQ_THEME_COLOR=
+
+# Optional promotional banner on the pricing and checkout pages.
+NEXT_PUBLIC_DISCOUNT_PERCENTAGE=
+NEXT_PUBLIC_DISCOUNT_CODE=

--- a/web/app/(app)/(auth)/(components)/login-with-google.tsx
+++ b/web/app/(app)/(auth)/(components)/login-with-google.tsx
@@ -7,17 +7,23 @@ import {
   GoogleLogin,
   GoogleOAuthProvider,
 } from '@react-oauth/google'
-import { signIn } from 'next-auth/react'
+import { getSession, signIn } from 'next-auth/react'
 import { useRouter, useSearchParams } from 'next/navigation'
+import { readAttribution } from '@/lib/analytics/attribution'
+import { track } from '@/lib/analytics/track'
 
 // The provider lives here rather than in the app-wide tree so the Google
 // Identity SDK is only loaded on the two pages that render this button
 // (login and register) instead of on every dashboard page.
 export default function LoginWithGoogle() {
+  const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID
+  // Without a client id there is no Google sign-in to offer, and rendering the
+  // provider anyway would load Google's SDK on a self-hosted instance that
+  // never configured it.
+  if (!clientId) return null
+
   return (
-    <GoogleOAuthProvider
-      clientId={process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID ?? ''}
-    >
+    <GoogleOAuthProvider clientId={clientId}>
       <GoogleLoginButton />
     </GoogleOAuthProvider>
   )
@@ -31,16 +37,39 @@ function GoogleLoginButton() {
   const onGoogleLoginSuccess = async (
     credentialResponse: CredentialResponse
   ) => {
+    // This button also serves /login, so attribution is sent every time and the
+    // API applies it only when it creates the account.
+    const attribution = readAttribution()
+    const destination = redirect ? decodeURIComponent(redirect) : Routes.dashboard
+
+    // redirect:false on purpose: with redirect:true the browser navigates away
+    // and this promise never resolves, so a first sign-in could never be told
+    // apart from a returning one.
+    const result = await signIn('google-id-token-login', {
+      redirect: false,
+      idToken: credentialResponse.credential,
+      ...(attribution && { attribution: JSON.stringify(attribution) }),
+    })
+
+    if (result?.error) {
+      toast({
+        title: 'Error',
+        description: 'Could not sign you in with Google',
+        variant: 'destructive',
+      })
+      return
+    }
+
     toast({
       title: 'Success',
       description: 'You are logged in with Google',
       variant: 'default',
     })
-    await signIn('google-id-token-login', {
-      redirect: true,
-      callbackUrl: redirect ? decodeURIComponent(redirect) : Routes.dashboard,
-      idToken: credentialResponse.credential,
-    })
+
+    const session = await getSession()
+    if (session?.user?.isNewUser) track('sign_up', { method: 'google' })
+
+    router.push(destination)
   }
 
   const onGoogleLoginError = () => {

--- a/web/app/(app)/(auth)/(components)/register-form.tsx
+++ b/web/app/(app)/(auth)/(components)/register-form.tsx
@@ -20,6 +20,8 @@ import { signIn } from 'next-auth/react'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Routes } from '@/config/routes'
 import { useTurnstile } from '@/lib/turnstile'
+import { readAttribution } from '@/lib/analytics/attribution'
+import { track } from '@/lib/analytics/track'
 
 const registerSchema = z.object({
   name: z
@@ -96,6 +98,11 @@ export default function RegisterForm() {
       return
     }
 
+    // Spread conditionally: next-auth serialises these options through
+    // URLSearchParams, so an undefined value would arrive as the string
+    // "undefined" and fail to parse on the other side.
+    const attribution = readAttribution()
+
     try {
       const result = await signIn('email-password-register', {
         redirect: false,
@@ -104,6 +111,7 @@ export default function RegisterForm() {
         name: data.name,
         phone: data.phone,
         marketingOptIn: data.marketingOptIn,
+        ...(attribution && { attribution: JSON.stringify(attribution) }),
         turnstileToken: data.turnstileToken,
       })
 
@@ -114,6 +122,7 @@ export default function RegisterForm() {
           message: 'Failed to create account',
         })
       } else {
+        track('sign_up', { method: 'email' })
         router.push(`${Routes.verifyEmail}?verificationEmailSent=1`)
       }
     } catch (error) {

--- a/web/app/(app)/checkout/[planName]/page.tsx
+++ b/web/app/(app)/checkout/[planName]/page.tsx
@@ -20,6 +20,7 @@ import {
   type BillingInterval,
 } from '@/lib/plans'
 import { Routes } from '@/config/routes'
+import { track } from '@/lib/analytics/track'
 import { cn } from '@/lib/utils'
 
 interface PlanChangePreview {
@@ -109,6 +110,10 @@ export default function CheckoutPage({
         )
 
         if (response.data?.redirectUrl) {
+          track('begin_checkout', {
+            plan: planName,
+            billing_interval: billingInterval,
+          })
           window.location.href = response.data?.redirectUrl
         } else if (response.data?.planChange) {
           // user already has a paid subscription: confirm before updating it

--- a/web/app/(app)/layout.tsx
+++ b/web/app/(app)/layout.tsx
@@ -4,7 +4,7 @@ import { authOptions } from '@/lib/auth'
 import { getServerSession, Session } from 'next-auth'
 import AppHeader from '@/components/shared/app-header'
 import Providers from './providers'
-import Analytics from '@/components/shared/analytics'
+import AnalyticsIdentify from '@/components/shared/analytics-identify'
 import { Toaster } from '@/components/ui/toaster'
 import SupportHQWidget from '@/components/shared/support-hq-widget'
 
@@ -18,7 +18,7 @@ export default async function RootLayout({ children }: PropsWithChildren) {
           full-width footer at this level gets painted over on its left edge.
           Each section renders the footer inside its own content column. */}
       <main className='min-h-[80vh]'>{children}</main>
-      <Analytics user={session?.user} />
+      <AnalyticsIdentify />
       <SupportHQWidget />
       <Toaster />
     </Providers>

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -3,6 +3,8 @@ import '@/styles/main.css'
 import { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 import ThemeProvider from './theme-provider'
+import Analytics from '@/components/shared/analytics'
+import AttributionCapture from '@/components/shared/attribution-capture'
 
 const inter = Inter({
   subsets: ['latin'],
@@ -30,6 +32,8 @@ export default async function RootLayout({ children }: PropsWithChildren) {
         >
           {children}
         </ThemeProvider>
+        <Analytics />
+        <AttributionCapture />
       </body>
     </html>
   )

--- a/web/components/shared/analytics-gating.test.tsx
+++ b/web/components/shared/analytics-gating.test.tsx
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { render } from '@testing-library/react'
+
+/*
+ * textbee is open source. A self-hosted dashboard must not report into the
+ * hosted service's analytics accounts, so every third-party script is gated on
+ * an env var and nothing loads when none is set.
+ *
+ * e2e/no-third-party.spec.ts checks the same promise against a real build.
+ */
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null, status: 'unauthenticated' }),
+}))
+
+async function freshRender(
+  component: 'analytics' | 'support-hq' | 'google'
+) {
+  vi.resetModules()
+  if (component === 'analytics') {
+    const { default: Analytics } = await import('@/components/shared/analytics')
+    return render(<Analytics />)
+  }
+  if (component === 'support-hq') {
+    const { default: SupportHQWidget } = await import(
+      '@/components/shared/support-hq-widget'
+    )
+    return render(<SupportHQWidget />)
+  }
+  const { default: LoginWithGoogle } = await import(
+    '@/app/(app)/(auth)/(components)/login-with-google'
+  )
+  return render(<LoginWithGoogle />)
+}
+
+function loadedScripts(): string {
+  return Array.from(document.querySelectorAll('script'))
+    .map((script) => script.getAttribute('src') ?? script.textContent ?? '')
+    .join(' ')
+}
+
+describe('third-party script gating', () => {
+  beforeEach(() => {
+    document.head.innerHTML = ''
+    document.body.innerHTML = ''
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.resetModules()
+  })
+
+  it('loads no analytics provider when none is configured', async () => {
+    vi.stubEnv('NEXT_PUBLIC_ANALYTICS_PROVIDERS', '')
+    const { container } = await freshRender('analytics')
+
+    const markup = container.innerHTML + loadedScripts()
+    expect(markup).not.toContain('googletagmanager.com')
+    expect(markup).not.toContain('clarity.ms')
+    expect(markup).not.toContain('connect.facebook.net')
+  })
+
+  it('skips a provider that is listed but has no id', async () => {
+    vi.stubEnv('NEXT_PUBLIC_ANALYTICS_PROVIDERS', 'ga,clarity,meta')
+    vi.stubEnv('NEXT_PUBLIC_GA_MEASUREMENT_ID', '')
+    vi.stubEnv('NEXT_PUBLIC_CLARITY_PROJECT_ID', '')
+    vi.stubEnv('NEXT_PUBLIC_META_PIXEL_ID', '')
+
+    const { container } = await freshRender('analytics')
+    const markup = container.innerHTML + loadedScripts()
+    expect(markup).not.toContain('googletagmanager.com')
+    expect(markup).not.toContain('clarity.ms')
+    expect(markup).not.toContain('connect.facebook.net')
+  })
+
+  it('loads only the providers that are listed and configured', async () => {
+    vi.stubEnv('NEXT_PUBLIC_ANALYTICS_PROVIDERS', 'ga')
+    vi.stubEnv('NEXT_PUBLIC_GA_MEASUREMENT_ID', 'G-UNITTEST')
+    vi.stubEnv('NEXT_PUBLIC_CLARITY_PROJECT_ID', 'unitclarity')
+
+    const { container } = await freshRender('analytics')
+    const markup = container.innerHTML + loadedScripts()
+
+    expect(markup).toContain('G-UNITTEST')
+    expect(markup).not.toContain('clarity.ms')
+  })
+
+  it('never sends the signed-in email to Google Analytics', async () => {
+    vi.stubEnv('NEXT_PUBLIC_ANALYTICS_PROVIDERS', 'ga,clarity')
+    vi.stubEnv('NEXT_PUBLIC_GA_MEASUREMENT_ID', 'G-UNITTEST')
+    vi.stubEnv('NEXT_PUBLIC_CLARITY_PROJECT_ID', 'unitclarity')
+
+    const { container } = await freshRender('analytics')
+    const markup = container.innerHTML + loadedScripts()
+
+    // The root-mounted component has no session at all, so no identifier can
+    // leak into either tag from here.
+    expect(markup).not.toContain('userId')
+  })
+
+  it('loads no support widget without a project id', async () => {
+    vi.stubEnv('NEXT_PUBLIC_SUPPORT_HQ_PROJECT_ID', '')
+    await freshRender('support-hq')
+    expect(loadedScripts()).not.toContain('cdn.supporthq.app')
+  })
+
+  it('loads the support widget once a project id is set', async () => {
+    vi.stubEnv('NEXT_PUBLIC_SUPPORT_HQ_PROJECT_ID', 'unit-project')
+    await freshRender('support-hq')
+    expect(loadedScripts()).toContain('cdn.supporthq.app')
+  })
+
+  it('renders no Google sign-in without a client id, so its SDK never loads', async () => {
+    vi.stubEnv('NEXT_PUBLIC_GOOGLE_CLIENT_ID', '')
+    const { container } = await freshRender('google')
+    expect(container.innerHTML).toBe('')
+  })
+})

--- a/web/components/shared/analytics-identify.tsx
+++ b/web/components/shared/analytics-identify.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useSession } from 'next-auth/react'
+import { isEnabled } from '@/lib/analytics/config'
+
+// Labels the Clarity session with the signed-in email so a support request can
+// be matched to a recording. Lives inside the session provider, unlike
+// <Analytics />, which is mounted at the root layout to cover signed-out pages.
+// Nothing is sent to Google Analytics here: its terms forbid personal data.
+export default function AnalyticsIdentify() {
+  const { data: session } = useSession()
+  const email = session?.user?.email ?? ''
+
+  useEffect(() => {
+    if (!email || !isEnabled('clarity')) return
+    window.clarity?.('set', 'userId', email)
+  }, [email])
+
+  return null
+}

--- a/web/components/shared/analytics.tsx
+++ b/web/components/shared/analytics.tsx
@@ -1,47 +1,79 @@
 'use client'
 
 import Script from 'next/script'
+import { isEnabled, providerId } from '@/lib/analytics/config'
 
-// Only the email is read, to tag the Clarity session.
-type AnalyticsProps = { user?: { email?: string | null } | null }
+// Every block is gated, so a self-hosted instance that configures no providers
+// loads no third-party script and reports to nobody. The Clarity session is
+// labelled separately by <AnalyticsIdentify />, which sits inside the session
+// provider; this component is mounted at the root and has no session.
+const Analytics = () => {
+  const gaId = isEnabled('ga') ? providerId('ga') : undefined
+  const clarityId = isEnabled('clarity') ? providerId('clarity') : undefined
+  const metaPixelId = isEnabled('meta') ? providerId('meta') : undefined
 
-const Analytics = ({ user }: AnalyticsProps) => {
   return (
     <>
-      {/* Global Site Tag (gtag.js) - Google Analytics  */}
-      <Script
-        id='gtag1'
-        strategy='afterInteractive'
-        src={`https://www.googletagmanager.com/gtag/js?id=G-MLD1JPRQZR`}
-      />
-      <Script
-        id='gtag2'
-        strategy='afterInteractive'
-        dangerouslySetInnerHTML={{
-          __html: `
+      {gaId && (
+        <>
+          <Script
+            id='gtag1'
+            strategy='afterInteractive'
+            src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
+          />
+          <Script
+            id='gtag2'
+            strategy='afterInteractive'
+            dangerouslySetInnerHTML={{
+              __html: `
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
-            gtag('config', 'G-MLD1JPRQZR', {
+            gtag('config', ${JSON.stringify(gaId)}, {
                 page_path: window.location.pathname,
             });
      `,
-        }}
-      />
-      <Script
-        id='ms-clarity1'
-        strategy='afterInteractive'
-        dangerouslySetInnerHTML={{
-          __html: `
+            }}
+          />
+        </>
+      )}
+
+      {clarityId && (
+        <Script
+          id='ms-clarity1'
+          strategy='afterInteractive'
+          dangerouslySetInnerHTML={{
+            __html: `
           (function(c,l,a,r,i,t,y){
             c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
             t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
             y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-            clarity('set', 'userId', '${user?.email || ''}');
-        })(window, document, "clarity", "script", "iacr7j4ozh");
+        })(window, document, "clarity", "script", ${JSON.stringify(clarityId)});
      `,
-        }}
-      />
+          }}
+        />
+      )}
+
+      {metaPixelId && (
+        <Script
+          id='meta-pixel'
+          strategy='afterInteractive'
+          dangerouslySetInnerHTML={{
+            __html: `
+          !function(f,b,e,v,n,t,s)
+          {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+          n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+          if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+          n.queue=[];t=b.createElement(e);t.async=!0;
+          t.src=v;s=b.getElementsByTagName(e)[0];
+          s.parentNode.insertBefore(t,s)}(window, document,'script',
+          'https://connect.facebook.net/en_US/fbevents.js');
+          fbq('init', ${JSON.stringify(metaPixelId)});
+          fbq('track', 'PageView');
+     `,
+          }}
+        />
+      )}
     </>
   )
 }

--- a/web/components/shared/attribution-capture.tsx
+++ b/web/components/shared/attribution-capture.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { useEffect } from 'react'
+import { captureTouch } from '@/lib/analytics/attribution'
+
+// Records first-touch and last-touch acquisition source in a first-party
+// cookie. No network request, so it runs regardless of analytics providers.
+export default function AttributionCapture() {
+  useEffect(() => {
+    captureTouch()
+  }, [])
+
+  return null
+}

--- a/web/components/shared/support-hq-widget.test.tsx
+++ b/web/components/shared/support-hq-widget.test.tsx
@@ -33,6 +33,9 @@ const fireLoad = () =>
   scripts().forEach((s) => (s as HTMLScriptElement).onload?.(new Event('load')))
 
 beforeEach(() => {
+  // The widget is gated on this: with no project id it loads nothing, which is
+  // the self-hosted default and is covered in analytics-gating.test.tsx.
+  vi.stubEnv('NEXT_PUBLIC_SUPPORT_HQ_PROJECT_ID', 'test-project')
   init.mockClear()
   destroy.mockClear()
   // @ts-ignore
@@ -40,6 +43,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  vi.unstubAllEnvs()
   document
     .querySelectorAll('script[src*="supporthq-widget.js"]')
     .forEach((s) => s.remove())

--- a/web/components/shared/support-hq-widget.tsx
+++ b/web/components/shared/support-hq-widget.tsx
@@ -4,6 +4,8 @@ import React, { useEffect } from 'react'
 
 export default function SupportHQWidget() {
   const { data: session } = useSession()
+  // Unset project id means no widget and no request to the widget CDN.
+  const projectId = process.env.NEXT_PUBLIC_SUPPORT_HQ_PROJECT_ID
 
   // Depended on as individual strings rather than as `session`: SessionProvider
   // hands back a new object on every refetch, and comparing that by reference
@@ -16,6 +18,8 @@ export default function SupportHQWidget() {
   const phone = session?.user?.phone ?? ''
 
   useEffect(() => {
+    if (!projectId) return
+
     let cancelled = false
 
     const script = document.createElement('script')
@@ -28,7 +32,7 @@ export default function SupportHQWidget() {
       if (cancelled) return
       // @ts-ignore
       window.SupportHQWidget?.init({
-        projectId: process.env.NEXT_PUBLIC_SUPPORT_HQ_PROJECT_ID,
+        projectId,
         themeColor: process.env.NEXT_PUBLIC_SUPPORT_HQ_THEME_COLOR ?? '#2563eb',
         ...(hasUser && {
           metadata: { userId, name, email, phone },
@@ -45,7 +49,7 @@ export default function SupportHQWidget() {
       // re-run used to add another one for the life of the page.
       script.remove()
     }
-  }, [hasUser, userId, name, email, phone])
+  }, [projectId, hasUser, userId, name, email, phone])
 
   return <></>
 }

--- a/web/e2e/no-third-party.spec.ts
+++ b/web/e2e/no-third-party.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test'
+
+/*
+ * textbee is open source, so a self-hosted dashboard must load no analytics or
+ * ad-platform script unless its operator opts in. The Playwright web server
+ * starts with no analytics env vars, which is exactly the self-host default.
+ *
+ * accounts.google.com is not on this list because the test server does set a
+ * Google client id, so Google sign-in is meant to load here. The unconfigured
+ * case for that one is covered in components/shared/analytics-gating.test.tsx.
+ */
+const BLOCKED_HOSTS = [
+  'googletagmanager.com',
+  'google-analytics.com',
+  'clarity.ms',
+  'connect.facebook.net',
+  'facebook.com/tr',
+  'static.ads-twitter.com',
+  'vercel-insights.com',
+  'cdn.supporthq.app',
+]
+
+const PAGES = ['/login', '/register', '/download']
+
+for (const path of PAGES) {
+  test(`${path} loads no third-party analytics when unconfigured`, async ({
+    page,
+  }) => {
+    const seen: string[] = []
+    page.on('request', (request) => {
+      const url = request.url()
+      if (BLOCKED_HOSTS.some((host) => url.includes(host))) seen.push(url)
+    })
+
+    // Not networkidle: the e2e server points the API at a host that never
+    // answers, so the page never goes idle. Analytics scripts load right after
+    // hydration, so a short settle after load is enough and is deterministic.
+    await page.goto(path, { waitUntil: 'load' })
+    await page.waitForTimeout(2000)
+
+    expect(seen, `unexpected third-party requests on ${path}`).toEqual([])
+  })
+}

--- a/web/lib/analytics/attribution.test.ts
+++ b/web/lib/analytics/attribution.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildTouch,
+  touchCounts,
+  mergeAttribution,
+  parseAttribution,
+  serializeAttribution,
+  readCookie,
+  buildCookieString,
+  isInternalReferrer,
+  ATTRIBUTION_COOKIE,
+  type Attribution,
+} from '@/lib/analytics/attribution'
+import { parseProviders } from '@/lib/analytics/config'
+
+const NOW = new Date('2026-09-11T10:00:00.000Z')
+
+describe('parseProviders', () => {
+  it('returns nothing for an unset list, which is the self-host default', () => {
+    expect(parseProviders('')).toEqual([])
+    expect(parseProviders('   ')).toEqual([])
+  })
+
+  it('trims, lowercases, and drops unknown names', () => {
+    expect(parseProviders(' GA , clarity,nope, meta ')).toEqual([
+      'ga',
+      'clarity',
+      'meta',
+    ])
+  })
+})
+
+describe('isInternalReferrer', () => {
+  it('treats the marketing site and the dashboard as one visit', () => {
+    expect(isInternalReferrer('textbee.dev', 'app.textbee.dev')).toBe(true)
+    expect(isInternalReferrer('app.textbee.dev', 'app.textbee.dev')).toBe(true)
+  })
+
+  it('keeps a genuine external referrer', () => {
+    expect(isInternalReferrer('l.facebook.com', 'textbee.dev')).toBe(false)
+    expect(isInternalReferrer('news.ycombinator.com', 'textbee.dev')).toBe(false)
+  })
+})
+
+describe('buildTouch', () => {
+  it('reads campaign parameters and click ids from the address', () => {
+    const touch = buildTouch({
+      search:
+        '?utm_source=meta&utm_medium=paid_social&utm_campaign=c1&utm_content=a1&utm_term=s1&fbclid=abc',
+      referrer: '',
+      pathname: '/pricing',
+      hostname: 'textbee.dev',
+      now: NOW,
+    })
+
+    expect(touch).toMatchObject({
+      source: 'meta',
+      medium: 'paid_social',
+      campaign: 'c1',
+      content: 'a1',
+      term: 's1',
+      fbclid: 'abc',
+      landingPath: '/pricing',
+      at: NOW.toISOString(),
+    })
+  })
+
+  it('records an external referrer host but not an internal one', () => {
+    expect(
+      buildTouch({
+        search: '',
+        referrer: 'https://www.reddit.com/r/selfhosted/comments/x',
+        pathname: '/',
+        hostname: 'textbee.dev',
+        now: NOW,
+      }).referrer
+    ).toBe('www.reddit.com')
+
+    expect(
+      buildTouch({
+        search: '',
+        referrer: 'https://app.textbee.dev/dashboard',
+        pathname: '/',
+        hostname: 'textbee.dev',
+        now: NOW,
+      }).referrer
+    ).toBeUndefined()
+  })
+
+  it('caps a field at 200 characters', () => {
+    const touch = buildTouch({
+      search: `?utm_campaign=${'x'.repeat(500)}`,
+      referrer: '',
+      pathname: '/',
+      hostname: 'textbee.dev',
+      now: NOW,
+    })
+    expect(touch.campaign).toHaveLength(200)
+  })
+
+  it('survives a malformed referrer', () => {
+    expect(
+      buildTouch({
+        search: '',
+        referrer: 'not a url',
+        pathname: '/',
+        hostname: 'textbee.dev',
+        now: NOW,
+      }).referrer
+    ).toBeUndefined()
+  })
+})
+
+describe('touchCounts', () => {
+  it('ignores a plain internal page view', () => {
+    expect(touchCounts({ landingPath: '/docs', at: NOW.toISOString() })).toBe(
+      false
+    )
+  })
+
+  it('counts a campaign, a ref link, or a click id', () => {
+    expect(touchCounts({ source: 'meta' })).toBe(true)
+    expect(touchCounts({ ref: 'reddit-selfhosted' })).toBe(true)
+    expect(touchCounts({ gclid: 'xyz' })).toBe(true)
+    expect(touchCounts({ referrer: 'news.ycombinator.com' })).toBe(true)
+  })
+})
+
+describe('mergeAttribution', () => {
+  it('stores nothing for a direct visit with no source', () => {
+    expect(mergeAttribution(null, { landingPath: '/' })).toBeNull()
+  })
+
+  it('sets first and last on the first campaign visit', () => {
+    const merged = mergeAttribution(null, { source: 'meta' })
+    expect(merged?.first?.source).toBe('meta')
+    expect(merged?.last?.source).toBe('meta')
+  })
+
+  it('keeps first touch and moves last touch on a later campaign', () => {
+    const first = mergeAttribution(null, { source: 'meta' })
+    const second = mergeAttribution(first, { source: 'reddit' })
+    expect(second?.first?.source).toBe('meta')
+    expect(second?.last?.source).toBe('reddit')
+  })
+
+  it('leaves both untouched when the visitor just browses on', () => {
+    const existing = mergeAttribution(null, { source: 'meta' })
+    const after = mergeAttribution(existing, { landingPath: '/pricing' })
+    expect(after).toBe(existing)
+  })
+})
+
+describe('parseAttribution', () => {
+  it('returns null for junk rather than throwing', () => {
+    expect(parseAttribution(null)).toBeNull()
+    expect(parseAttribution('')).toBeNull()
+    expect(parseAttribution('{oops')).toBeNull()
+    expect(parseAttribution('"a string"')).toBeNull()
+    expect(parseAttribution('{}')).toBeNull()
+  })
+
+  it('drops unknown keys and non-string values', () => {
+    const parsed = parseAttribution(
+      JSON.stringify({
+        first: { source: 'meta', evil: 'x', campaign: 42 },
+        last: { source: 'reddit' },
+      })
+    )
+    expect(parsed?.first).toEqual({ source: 'meta' })
+    expect(parsed?.last).toEqual({ source: 'reddit' })
+  })
+})
+
+describe('serializeAttribution', () => {
+  it('round-trips a normal value untouched', () => {
+    const attribution: Attribution = {
+      first: { source: 'meta', campaign: 'c1' },
+      last: { source: 'reddit' },
+    }
+    expect(parseAttribution(serializeAttribution(attribution))).toEqual(
+      attribution
+    )
+  })
+
+  it('sheds data rather than letting the browser drop an oversized cookie', () => {
+    const long = 'x'.repeat(200)
+    const fat: Attribution = {
+      first: {
+        source: long,
+        medium: long,
+        campaign: long,
+        content: long,
+        term: long,
+        ref: long,
+        referrer: long,
+        landingPath: long,
+        fbclid: long,
+        gclid: long,
+      },
+      last: {
+        source: long,
+        medium: long,
+        campaign: long,
+        content: long,
+        term: long,
+        ref: long,
+        referrer: long,
+        landingPath: long,
+        fbclid: long,
+        gclid: long,
+      },
+    }
+
+    const serialized = serializeAttribution(fat)
+    expect(encodeURIComponent(serialized).length).toBeLessThanOrEqual(3800)
+    expect(parseAttribution(serialized)?.first?.source).toBeTruthy()
+  })
+})
+
+describe('cookie helpers', () => {
+  it('reads one cookie out of many', () => {
+    const jar = `theme=dark; ${ATTRIBUTION_COOKIE}=${encodeURIComponent(
+      '{"first":{"source":"meta"}}'
+    )}; _fbp=fb.1.123.456`
+    expect(parseAttribution(readCookie(ATTRIBUTION_COOKIE, jar))?.first?.source).toBe(
+      'meta'
+    )
+    expect(readCookie('_fbp', jar)).toBe('fb.1.123.456')
+    expect(readCookie('missing', jar)).toBeNull()
+  })
+
+  it('adds the shared domain and Secure only when asked', () => {
+    const shared = buildCookieString('{}', {
+      domain: '.textbee.dev',
+      secure: true,
+    })
+    expect(shared).toContain('domain=.textbee.dev')
+    expect(shared).toContain('Secure')
+    expect(shared).toContain('SameSite=Lax')
+    expect(shared).toContain('max-age=7776000')
+
+    const local = buildCookieString('{}', { secure: false })
+    expect(local).not.toContain('domain=')
+    expect(local).not.toContain('Secure')
+  })
+})

--- a/web/lib/analytics/attribution.ts
+++ b/web/lib/analytics/attribution.ts
@@ -1,0 +1,243 @@
+// First-party acquisition attribution. Stores where a visitor came from in a
+// cookie on the shared domain so the signup endpoint can record it. Makes no
+// external request and is therefore always on, including for self-hosters.
+
+export const ATTRIBUTION_COOKIE = 'tb_attr'
+export const ATTRIBUTION_MAX_AGE_DAYS = 90
+
+const MAX_FIELD_LENGTH = 200
+const MAX_COOKIE_LENGTH = 3800
+
+export type Touch = {
+  source?: string
+  medium?: string
+  campaign?: string
+  content?: string
+  term?: string
+  ref?: string
+  referrer?: string
+  landingPath?: string
+  fbclid?: string
+  gclid?: string
+  at?: string
+}
+
+export type Attribution = {
+  first?: Touch
+  last?: Touch
+  fbp?: string
+}
+
+const TOUCH_FIELDS: (keyof Touch)[] = [
+  'source',
+  'medium',
+  'campaign',
+  'content',
+  'term',
+  'ref',
+  'referrer',
+  'landingPath',
+  'fbclid',
+  'gclid',
+  'at',
+]
+
+function clean(value: string | null | undefined): string | undefined {
+  if (!value) return undefined
+  const trimmed = value.trim().slice(0, MAX_FIELD_LENGTH)
+  return trimmed || undefined
+}
+
+// Approximates the registrable domain so a hop between textbee.dev and
+// app.textbee.dev is not counted as a new acquisition source.
+export function isInternalReferrer(
+  referrerHost: string,
+  currentHost: string
+): boolean {
+  if (!referrerHost) return true
+  if (referrerHost === currentHost) return true
+  const tail = (host: string) => host.split('.').slice(-2).join('.')
+  return tail(referrerHost) === tail(currentHost)
+}
+
+export function buildTouch({
+  search,
+  referrer,
+  pathname,
+  hostname,
+  now,
+}: {
+  search: string
+  referrer: string
+  pathname: string
+  hostname: string
+  now?: Date
+}): Touch {
+  const params = new URLSearchParams(search)
+
+  let referrerHost: string | undefined
+  if (referrer) {
+    try {
+      const host = new URL(referrer).hostname
+      if (!isInternalReferrer(host, hostname)) referrerHost = host
+    } catch {
+      referrerHost = undefined
+    }
+  }
+
+  return {
+    source: clean(params.get('utm_source')),
+    medium: clean(params.get('utm_medium')),
+    campaign: clean(params.get('utm_campaign')),
+    content: clean(params.get('utm_content')),
+    term: clean(params.get('utm_term')),
+    ref: clean(params.get('ref')),
+    referrer: clean(referrerHost),
+    landingPath: clean(pathname),
+    fbclid: clean(params.get('fbclid')),
+    gclid: clean(params.get('gclid')),
+    at: (now ?? new Date()).toISOString(),
+  }
+}
+
+// A visit only overwrites last-touch when it actually carries a source. Plain
+// internal navigation must not erase the campaign that brought someone here.
+export function touchCounts(touch: Touch): boolean {
+  return Boolean(
+    touch.source ||
+      touch.medium ||
+      touch.campaign ||
+      touch.ref ||
+      touch.fbclid ||
+      touch.gclid ||
+      touch.referrer
+  )
+}
+
+export function mergeAttribution(
+  existing: Attribution | null,
+  touch: Touch
+): Attribution | null {
+  const counts = touchCounts(touch)
+
+  if (!existing) {
+    return counts ? { first: touch, last: touch } : null
+  }
+  if (!counts) return existing
+
+  return { ...existing, first: existing.first ?? touch, last: touch }
+}
+
+function sanitizeTouch(value: unknown): Touch | undefined {
+  if (!value || typeof value !== 'object') return undefined
+  const input = value as Record<string, unknown>
+  const touch: Touch = {}
+  for (const field of TOUCH_FIELDS) {
+    const raw = input[field]
+    if (typeof raw === 'string') {
+      const cleaned = clean(raw)
+      if (cleaned) touch[field] = cleaned
+    }
+  }
+  return Object.keys(touch).length ? touch : undefined
+}
+
+export function parseAttribution(raw: string | null): Attribution | null {
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>
+    if (!parsed || typeof parsed !== 'object') return null
+    const attribution: Attribution = {}
+    const first = sanitizeTouch(parsed.first)
+    const last = sanitizeTouch(parsed.last)
+    if (first) attribution.first = first
+    if (last) attribution.last = last
+    return attribution.first || attribution.last ? attribution : null
+  } catch {
+    return null
+  }
+}
+
+// Browsers drop an oversized cookie silently, which would lose attribution
+// with no error, so shed data until it fits rather than risk the whole value.
+export function serializeAttribution(attribution: Attribution): string {
+  let candidate: Attribution = attribution
+  let encoded = encodeURIComponent(JSON.stringify(candidate))
+  if (encoded.length <= MAX_COOKIE_LENGTH) return JSON.stringify(candidate)
+
+  candidate = { first: attribution.first ?? attribution.last }
+  encoded = encodeURIComponent(JSON.stringify(candidate))
+  if (encoded.length <= MAX_COOKIE_LENGTH) return JSON.stringify(candidate)
+
+  const touch = candidate.first ?? {}
+  const trimmed: Touch = {}
+  for (const field of TOUCH_FIELDS) {
+    const value = touch[field]
+    if (value) trimmed[field] = value.slice(0, 40)
+  }
+  return JSON.stringify({ first: trimmed })
+}
+
+export function readCookie(name: string, cookieString: string): string | null {
+  const match = cookieString.match(
+    new RegExp(`(?:^|;\\s*)${name}=([^;]*)`)
+  )
+  return match ? decodeURIComponent(match[1]) : null
+}
+
+export function buildCookieString(
+  value: string,
+  {
+    domain,
+    secure,
+    maxAgeDays = ATTRIBUTION_MAX_AGE_DAYS,
+  }: { domain?: string; secure: boolean; maxAgeDays?: number }
+): string {
+  const parts = [
+    `${ATTRIBUTION_COOKIE}=${encodeURIComponent(value)}`,
+    'path=/',
+    `max-age=${maxAgeDays * 24 * 60 * 60}`,
+    'SameSite=Lax',
+  ]
+  if (domain) parts.push(`domain=${domain}`)
+  if (secure) parts.push('Secure')
+  return parts.join('; ')
+}
+
+export function captureTouch(): Attribution | null {
+  if (typeof document === 'undefined') return null
+
+  const touch = buildTouch({
+    search: window.location.search,
+    referrer: document.referrer,
+    pathname: window.location.pathname,
+    hostname: window.location.hostname,
+  })
+
+  const existing = parseAttribution(
+    readCookie(ATTRIBUTION_COOKIE, document.cookie)
+  )
+  const merged = mergeAttribution(existing, touch)
+  if (!merged || merged === existing) return merged
+
+  document.cookie = buildCookieString(serializeAttribution(merged), {
+    domain: process.env.NEXT_PUBLIC_ATTRIBUTION_COOKIE_DOMAIN,
+    secure: window.location.protocol === 'https:',
+  })
+
+  return merged
+}
+
+export function readAttribution(): Attribution | null {
+  if (typeof document === 'undefined') return null
+
+  const attribution = parseAttribution(
+    readCookie(ATTRIBUTION_COOKIE, document.cookie)
+  )
+
+  // Read _fbp live rather than copying it at capture time: on an ad click the
+  // pixel script has usually not run yet when the capture effect fires.
+  const fbp = readCookie('_fbp', document.cookie)
+  if (!attribution) return fbp ? { fbp } : null
+  return fbp ? { ...attribution, fbp } : attribution
+}

--- a/web/lib/analytics/config.ts
+++ b/web/lib/analytics/config.ts
@@ -1,0 +1,54 @@
+// Analytics providers load only when named here AND given an id, so an
+// instance with no configuration loads no third-party scripts at all.
+
+export type AnalyticsProvider = 'ga' | 'clarity' | 'meta'
+
+const KNOWN_PROVIDERS: AnalyticsProvider[] = ['ga', 'clarity', 'meta']
+
+// Next inlines process.env.NEXT_PUBLIC_* at build time only for full static
+// member expressions, so each one is read literally rather than by lookup.
+const RAW_PROVIDERS = process.env.NEXT_PUBLIC_ANALYTICS_PROVIDERS ?? ''
+
+const PROVIDER_IDS: Record<AnalyticsProvider, string | undefined> = {
+  ga: process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID,
+  clarity: process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID,
+  meta: process.env.NEXT_PUBLIC_META_PIXEL_ID,
+}
+
+export function parseProviders(raw: string): AnalyticsProvider[] {
+  return raw
+    .split(',')
+    .map((name) => name.trim().toLowerCase())
+    .filter((name): name is AnalyticsProvider =>
+      (KNOWN_PROVIDERS as string[]).includes(name)
+    )
+}
+
+const enabledProviders = parseProviders(RAW_PROVIDERS)
+
+const warned = new Set<string>()
+
+export function providerId(provider: AnalyticsProvider): string | undefined {
+  const id = PROVIDER_IDS[provider]
+  return id && id.trim() ? id.trim() : undefined
+}
+
+export function isEnabled(provider: AnalyticsProvider): boolean {
+  if (!enabledProviders.includes(provider)) return false
+
+  if (!providerId(provider)) {
+    if (process.env.NODE_ENV === 'development' && !warned.has(provider)) {
+      warned.add(provider)
+      console.warn(
+        `[analytics] "${provider}" is listed in NEXT_PUBLIC_ANALYTICS_PROVIDERS but its id env var is empty, so it will not load.`
+      )
+    }
+    return false
+  }
+
+  return true
+}
+
+export function enabledProviderList(): AnalyticsProvider[] {
+  return enabledProviders.filter(isEnabled)
+}

--- a/web/lib/analytics/track.ts
+++ b/web/lib/analytics/track.ts
@@ -1,0 +1,16 @@
+import { isEnabled } from './config'
+
+declare global {
+  interface Window {
+    gtag?: (...args: any[]) => void
+    fbq?: (...args: any[]) => void
+    clarity?: (...args: any[]) => void
+  }
+}
+
+// Never pass an email or a user id here. Google's terms forbid sending
+// personal identifiers to Analytics.
+export function track(event: string, props: Record<string, any> = {}) {
+  if (typeof window === 'undefined') return
+  if (isEnabled('ga')) window.gtag?.('event', event, props)
+}

--- a/web/lib/auth.ts
+++ b/web/lib/auth.ts
@@ -13,6 +13,7 @@ declare module 'next-auth' {
       phone?: string
       avatar?: string
       accessToken?: string
+      isNewUser?: boolean
     } & DefaultSession['user']
   }
 
@@ -24,6 +25,7 @@ declare module 'next-auth' {
     phone?: string
     avatar?: string
     accessToken?: string
+    isNewUser?: boolean
   }
 }
 
@@ -36,6 +38,20 @@ declare module 'next-auth/jwt' {
     phone?: string
     avatar?: string
     accessToken?: string
+    isNewUser?: boolean
+  }
+}
+
+
+// Credentials cross the wire as strings, so the attribution blob arrives as
+// JSON. A bad value must not block a signup, so parsing failures are dropped.
+function parseAttribution(raw: unknown) {
+  if (typeof raw !== 'string' || !raw || raw === 'undefined') return undefined
+  try {
+    const parsed = JSON.parse(raw)
+    return parsed && typeof parsed === 'object' ? parsed : undefined
+  } catch {
+    return undefined
   }
 }
 
@@ -84,6 +100,8 @@ export const authOptions: NextAuthOptions = {
         password: { label: 'Password', type: 'password' },
         name: { label: 'Name', type: 'text' },
         phone: { label: 'Phone', type: 'text' },
+        marketingOptIn: { label: 'Marketing Opt In', type: 'text' },
+        attribution: { label: 'Attribution', type: 'text' },
         turnstileToken: { label: 'Turnstile Token', type: 'text' },
       },
       async authorize(credentials) {
@@ -97,6 +115,9 @@ export const authOptions: NextAuthOptions = {
               password,
               name,
               phone,
+              // Arrives as a string, and Boolean('false') is true.
+              marketingOptIn: credentials.marketingOptIn === 'true',
+              attribution: parseAttribution(credentials.attribution),
               turnstileToken,
             }
           )
@@ -119,6 +140,7 @@ export const authOptions: NextAuthOptions = {
       name: 'google-id-token-login',
       credentials: {
         idToken: { label: 'idToken', type: 'text' },
+        attribution: { label: 'Attribution', type: 'text' },
       },
       async authorize(credentials) {
         if (!credentials) return null
@@ -128,6 +150,7 @@ export const authOptions: NextAuthOptions = {
             ApiEndpoints.auth.signInWithGoogle(),
             {
               idToken,
+              attribution: parseAttribution(credentials.attribution),
             }
           )
 
@@ -137,6 +160,7 @@ export const authOptions: NextAuthOptions = {
           return {
             ...user,
             accessToken,
+            isNewUser: res.data.data.isNewUser === true,
           }
         } catch (e) {
           console.log(e)
@@ -170,6 +194,7 @@ export const authOptions: NextAuthOptions = {
         token.accessToken = user.accessToken
         token.avatar = user.avatar
         token.phone = user.phone
+        token.isNewUser = user.isNewUser
       }
       return token
     },
@@ -179,6 +204,7 @@ export const authOptions: NextAuthOptions = {
       session.user.accessToken = token.accessToken
       session.user.avatar = token.avatar
       session.user.phone = token.phone
+      session.user.isNewUser = token.isNewUser
       return session
     },
   },

--- a/web/test/third-party-hosts.ts
+++ b/web/test/third-party-hosts.ts
@@ -1,0 +1,14 @@
+// Hosts that must never be contacted by an instance with no analytics
+// providers configured. Shared by the vitest gating test and the Playwright
+// self-host check so the two can never drift apart.
+export const BLOCKED_HOSTS = [
+  'googletagmanager.com',
+  'google-analytics.com',
+  'clarity.ms',
+  'connect.facebook.net',
+  'facebook.com/tr',
+  'static.ads-twitter.com',
+  'vercel-insights.com',
+  'cdn.supporthq.app',
+  'accounts.google.com',
+]


### PR DESCRIPTION
Makes analytics opt-in and adds a signup source field.

## Analytics are opt-in

`web/components/shared/analytics.tsx` hardcoded the Google Analytics and Clarity ids, so any self-hosted instance reported into our properties, with the signed-in email attached to the Clarity session.

Providers now come from env vars, and each needs its own id:

- `NEXT_PUBLIC_ANALYTICS_PROVIDERS` for browser scripts (`ga`, `clarity`, `meta`)
- `ANALYTICS_PROVIDERS` for server-side events (`meta`)

Unset means no script loads and no event is sent. The SupportHQ widget and the Google sign-in SDK are gated the same way; both loaded unconditionally before. Documented in the README.

## Signup source

A first-party cookie records where a visit came from (campaign parameters, referring host, landing path). The register and Google sign-in endpoints store it on the account as `signupSource` plus the raw values. It stays in your own database.

Milestone timestamps (`firstDeviceAt`, `firstApiKeyAt`, `firstSmsAt`, `firstPaidAt`) are stamped once each through an `$exists` filtered update.

Optionally, when configured, the API can forward conversion events to Meta's Conversions API with hashed identifiers.

## Fixes along the way

- `app.set('trust proxy', 1)`. Without it `req.ip` was the proxy loopback on every request.
- `marketingOptIn` now reaches the database. The signup checkbox was a no-op.
- Google sign-in used `redirect: true`, so the promise never resolved.
- `<Analytics />` moves to the root layout, so `/download` is covered.
- Removed em dashes from the README and one user-facing error message.

## Testing

505 API and 237 web tests pass. New coverage for source normalisation, input sanitisation against oversized and prototype-polluting payloads, the Meta payload shape, provider gating, first-payment idempotency, and module wiring.

`web/e2e/no-third-party.spec.ts` loads a real production build with nothing configured and asserts no request to any analytics host.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable Google Analytics, Microsoft Clarity, and Meta tracking.
  - Added signup attribution tracking for campaign sources, referrers, and ad clicks.
  - Added checkout, registration, and purchase event reporting.
  - Added optional support-chat widget and discount-banner configuration.
  - Added first-party attribution cookies without external requests.

- **Privacy**
  - Self-hosted instances send no analytics data unless providers are explicitly configured.
  - Third-party scripts now load only when both enabled and properly configured.

- **Bug Fixes**
  - Improved Google sign-in handling when configuration is missing or authentication fails.
  - Improved email validation and client IP detection behind reverse proxies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->