### PR TITLE
Record the visitor's browser details rather than the proxy's

### DIFF
--- a/api/src/auth/auth.controller.ts
+++ b/api/src/auth/auth.controller.ts
@@ -40,6 +40,7 @@ import {
 } from './auth.dto'
 import { AuthGuard } from './guards/auth.guard'
 import { AuthService } from './auth.service'
+import { resolveRequestContext } from '../common/request-context'
 import { UsersService } from '../users/users.service'
 import { CanModifyApiKey } from './guards/can-modify-api-key.guard'
 
@@ -106,8 +107,7 @@ export class AuthController {
   async googleLogin(@Body() input: GoogleLoginInputDTO, @Request() req) {
     const data = await this.authService.loginWithGoogle(input.idToken, {
       attribution: input.attribution,
-      ip: req.ip,
-      userAgent: req.headers?.['user-agent'],
+      ...resolveRequestContext(input.client, req),
     })
     return { data }
   }
@@ -128,10 +128,10 @@ export class AuthController {
   })
   @Post('/register')
   async register(@Body() input: RegisterInputDTO, @Request() req) {
-    const data = await this.authService.register(input, {
-      ip: req.ip,
-      userAgent: req.headers?.['user-agent'],
-    })
+    const data = await this.authService.register(
+      input,
+      resolveRequestContext(input.client, req),
+    )
     return { data }
   }
 

--- a/api/src/auth/auth.dto.ts
+++ b/api/src/auth/auth.dto.ts
@@ -107,6 +107,24 @@ export class AttributionDTO {
   fbp?: string
 }
 
+export class ClientContextDTO {
+  @ApiProperty({
+    type: String,
+    required: false,
+    description:
+      "The visitor's browser user agent. Sent by the dashboard because it proxies this call, so the request itself carries the dashboard server's user agent rather than the visitor's.",
+  })
+  userAgent?: string
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description:
+      "The visitor's IP address, forwarded for the same reason. Used only to label analytics, never for access control.",
+  })
+  ip?: string
+}
+
 export class RegisterInputDTO {
   @ApiProperty({
     type: String,
@@ -155,6 +173,13 @@ export class RegisterInputDTO {
   attribution?: AttributionDTO
 
   @ApiProperty({
+    type: ClientContextDTO,
+    required: false,
+    description: "The visitor's browser details, when the caller is a proxy.",
+  })
+  client?: ClientContextDTO
+
+  @ApiProperty({
     type: String,
     required: true,
     description: 'Cloudflare Turnstile token from the signup form.',
@@ -198,6 +223,13 @@ export class GoogleLoginInputDTO {
       'Where this signup came from. Recorded only when this call creates the account.',
   })
   attribution?: AttributionDTO
+
+  @ApiProperty({
+    type: ClientContextDTO,
+    required: false,
+    description: "The visitor's browser details, when the caller is a proxy.",
+  })
+  client?: ClientContextDTO
 }
 
 export class RequestResetPasswordInputDTO {

--- a/api/src/common/request-context.spec.ts
+++ b/api/src/common/request-context.spec.ts
@@ -1,0 +1,98 @@
+import { resolveRequestContext } from './request-context'
+
+/*
+ * The dashboard proxies registration, so without forwarding, every account was
+ * recorded with the dashboard server's user agent and address. That made
+ * signupDevice useless and sent the wrong browser context to ad platforms,
+ * which hurts identity matching more than sending nothing would.
+ */
+describe('resolveRequestContext', () => {
+  const proxyReq = {
+    ip: '10.0.0.1',
+    headers: { 'user-agent': 'axios/1.7.2' },
+  }
+
+  it('prefers the forwarded browser values over the proxy request', () => {
+    expect(
+      resolveRequestContext(
+        {
+          userAgent: 'Mozilla/5.0 (Linux; Android 14; Pixel 8)',
+          ip: '203.0.113.4',
+        },
+        proxyReq,
+      ),
+    ).toEqual({
+      userAgent: 'Mozilla/5.0 (Linux; Android 14; Pixel 8)',
+      ip: '203.0.113.4',
+    })
+  })
+
+  it('falls back to the request when nothing is forwarded', () => {
+    expect(resolveRequestContext(undefined, proxyReq)).toEqual({
+      userAgent: 'axios/1.7.2',
+      ip: '10.0.0.1',
+    })
+  })
+
+  it('falls back per field, not all or nothing', () => {
+    expect(resolveRequestContext({ ip: '203.0.113.4' }, proxyReq)).toEqual({
+      userAgent: 'axios/1.7.2',
+      ip: '203.0.113.4',
+    })
+  })
+
+  it('returns nothing rather than guessing when there is no source at all', () => {
+    expect(resolveRequestContext(undefined, undefined)).toEqual({
+      userAgent: undefined,
+      ip: undefined,
+    })
+  })
+
+  describe('treats the forwarded values as untrusted', () => {
+    it('ignores non-strings', () => {
+      expect(
+        resolveRequestContext({ userAgent: { $ne: null }, ip: 42 }, undefined),
+      ).toEqual({ userAgent: undefined, ip: undefined })
+    })
+
+    it('caps a long user agent', () => {
+      const result = resolveRequestContext(
+        { userAgent: 'x'.repeat(5000) },
+        undefined,
+      )
+      expect(result.userAgent).toHaveLength(512)
+    })
+
+    it('strips control characters so a log line cannot be forged', () => {
+      const injected = 'Mozilla/5.0\r\n[Nest] LOG fake entry'
+      const result = resolveRequestContext({ userAgent: injected }, undefined)
+
+      expect(result.userAgent).not.toContain('\n')
+      expect(result.userAgent).not.toContain('\r')
+      expect(result.userAgent).toBe('Mozilla/5.0[Nest] LOG fake entry')
+    })
+
+    it('rejects an address that is not address shaped', () => {
+      for (const bad of [
+        'not-an-ip',
+        '<script>alert(1)</script>',
+        '203.0.113.4; DROP',
+        'x'.repeat(60),
+        '',
+        '   ',
+      ]) {
+        expect(resolveRequestContext({ ip: bad }, undefined).ip).toBeUndefined()
+      }
+    })
+
+    it('accepts ordinary IPv4 and IPv6 forms', () => {
+      for (const good of [
+        '203.0.113.4',
+        '2001:db8::8a2e:370:7334',
+        '::ffff:203.0.113.4',
+      ]) {
+        expect(resolveRequestContext({ ip: good }, undefined).ip).toBe(good)
+      }
+    })
+  })
+})

--- a/api/src/common/request-context.ts
+++ b/api/src/common/request-context.ts
@@ -1,0 +1,54 @@
+// The dashboard proxies registration through its own server, so the request the
+// API sees comes from that server rather than from the visitor. The browser's
+// user agent and address are therefore forwarded in the body, and these helpers
+// decide which value to trust.
+//
+// Body values are attacker controlled. They are used only to label analytics,
+// never for authorisation or rate limiting, and are bounded here so a hostile
+// payload cannot grow a document or forge a log line.
+
+const MAX_USER_AGENT = 512
+const MAX_IP = 45 // longest IPv6 form, including an embedded IPv4 tail
+
+// Control characters, which would otherwise let a forwarded value inject
+// newlines into logs.
+const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/g
+
+export type ClientContextInput = {
+  userAgent?: unknown
+  ip?: unknown
+}
+
+export type RequestContext = {
+  ip?: string
+  userAgent?: string
+}
+
+function cleanUserAgent(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.replace(CONTROL_CHARACTERS, '').trim()
+  return trimmed ? trimmed.slice(0, MAX_USER_AGENT) : undefined
+}
+
+function cleanIp(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  if (!trimmed || trimmed.length > MAX_IP) return undefined
+  // A shape check rather than a validity check: enough to keep arbitrary text
+  // out of the field without reimplementing an address parser.
+  return /^[0-9a-fA-F:.]+$/.test(trimmed) ? trimmed : undefined
+}
+
+export function resolveRequestContext(
+  client: ClientContextInput | undefined,
+  req?: { ip?: string; headers?: Record<string, any> },
+): RequestContext {
+  const forwardedUserAgent = cleanUserAgent(client?.userAgent)
+  const forwardedIp = cleanIp(client?.ip)
+
+  return {
+    userAgent:
+      forwardedUserAgent ?? cleanUserAgent(req?.headers?.['user-agent']),
+    ip: forwardedIp ?? cleanIp(req?.ip),
+  }
+}

--- a/web/lib/analytics/client-context.test.ts
+++ b/web/lib/analytics/client-context.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import {
+  clientIpFromHeaders,
+  clientContextFromHeaders,
+} from '@/lib/analytics/client-context'
+
+/*
+ * Registration is posted to the API by this Next server, not by the browser, so
+ * unless the browser's own details are read here and forwarded, every account
+ * is recorded against the server instead of the visitor.
+ */
+describe('clientIpFromHeaders', () => {
+  it('takes the client from the front of the forwarded chain', () => {
+    expect(
+      clientIpFromHeaders({
+        'x-forwarded-for': '203.0.113.4, 70.41.3.18, 150.172.238.178',
+      })
+    ).toBe('203.0.113.4')
+  })
+
+  it('handles a single address with no chain', () => {
+    expect(clientIpFromHeaders({ 'x-forwarded-for': '203.0.113.4' })).toBe(
+      '203.0.113.4'
+    )
+  })
+
+  it('handles the header arriving as an array', () => {
+    expect(
+      clientIpFromHeaders({ 'x-forwarded-for': ['203.0.113.4', '10.0.0.1'] })
+    ).toBe('203.0.113.4')
+  })
+
+  it('falls back to x-real-ip', () => {
+    expect(clientIpFromHeaders({ 'x-real-ip': '203.0.113.9' })).toBe(
+      '203.0.113.9'
+    )
+  })
+
+  it('returns nothing when there is no address header', () => {
+    expect(clientIpFromHeaders({})).toBeUndefined()
+    expect(clientIpFromHeaders(undefined)).toBeUndefined()
+    expect(clientIpFromHeaders({ 'x-forwarded-for': '' })).toBeUndefined()
+  })
+})
+
+describe('clientContextFromHeaders', () => {
+  it('collects the browser user agent and address', () => {
+    expect(
+      clientContextFromHeaders({
+        'user-agent': 'Mozilla/5.0 (Linux; Android 14; Pixel 8)',
+        'x-forwarded-for': '203.0.113.4',
+      })
+    ).toEqual({
+      userAgent: 'Mozilla/5.0 (Linux; Android 14; Pixel 8)',
+      ip: '203.0.113.4',
+    })
+  })
+
+  it('omits a field rather than sending an empty one', () => {
+    expect(
+      clientContextFromHeaders({ 'user-agent': 'Mozilla/5.0' })
+    ).toEqual({ userAgent: 'Mozilla/5.0' })
+  })
+
+  it('returns undefined when there is nothing worth sending', () => {
+    expect(clientContextFromHeaders({})).toBeUndefined()
+    expect(clientContextFromHeaders(undefined)).toBeUndefined()
+  })
+
+  it('caps an absurd user agent before it leaves the server', () => {
+    const result = clientContextFromHeaders({ 'user-agent': 'x'.repeat(5000) })
+    expect(result?.userAgent).toHaveLength(512)
+  })
+})

--- a/web/lib/analytics/client-context.ts
+++ b/web/lib/analytics/client-context.ts
@@ -1,0 +1,37 @@
+// Registration is proxied through this Next server, so by the time the request
+// reaches the API its user agent and address belong to the server, not the
+// visitor. These read the real values from the inbound browser request so they
+// can be forwarded explicitly.
+
+const MAX_USER_AGENT = 512
+
+type HeaderBag = Record<string, string | string[] | undefined> | undefined
+
+function first(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) return value[0]
+  return value
+}
+
+export function clientIpFromHeaders(headers: HeaderBag): string | undefined {
+  if (!headers) return undefined
+
+  // x-forwarded-for is a chain, client first, proxies after.
+  const forwarded = first(headers['x-forwarded-for'])
+  const candidate =
+    forwarded?.split(',')[0]?.trim() ||
+    first(headers['x-real-ip'])?.trim() ||
+    undefined
+
+  return candidate || undefined
+}
+
+export function clientContextFromHeaders(headers: HeaderBag) {
+  const userAgent = first(headers?.['user-agent'])?.slice(0, MAX_USER_AGENT)
+  const ip = clientIpFromHeaders(headers)
+
+  if (!userAgent && !ip) return undefined
+  return {
+    ...(userAgent && { userAgent }),
+    ...(ip && { ip }),
+  }
+}

--- a/web/lib/auth.ts
+++ b/web/lib/auth.ts
@@ -3,6 +3,7 @@ import { httpServerClient } from './httpServerClient'
 import type { DefaultSession, NextAuthOptions } from 'next-auth'
 import { ApiEndpoints } from '@/config/api'
 import { Routes } from '@/config/routes'
+import { clientContextFromHeaders } from '@/lib/analytics/client-context'
 
 // add custom fields to the session and user interfaces
 declare module 'next-auth' {
@@ -104,7 +105,7 @@ export const authOptions: NextAuthOptions = {
         attribution: { label: 'Attribution', type: 'text' },
         turnstileToken: { label: 'Turnstile Token', type: 'text' },
       },
-      async authorize(credentials) {
+      async authorize(credentials, req) {
         if (!credentials) return null
         const { email, password, name, phone, turnstileToken } = credentials
         try {
@@ -118,6 +119,9 @@ export const authOptions: NextAuthOptions = {
               // Arrives as a string, and Boolean('false') is true.
               marketingOptIn: credentials.marketingOptIn === 'true',
               attribution: parseAttribution(credentials.attribution),
+              // Without this the API would record this server's address and
+              // user agent instead of the visitor's.
+              client: clientContextFromHeaders(req?.headers),
               turnstileToken,
             }
           )
@@ -142,7 +146,7 @@ export const authOptions: NextAuthOptions = {
         idToken: { label: 'idToken', type: 'text' },
         attribution: { label: 'Attribution', type: 'text' },
       },
-      async authorize(credentials) {
+      async authorize(credentials, req) {
         if (!credentials) return null
         const { idToken } = credentials
         try {
@@ -151,6 +155,7 @@ export const authOptions: NextAuthOptions = {
             {
               idToken,
               attribution: parseAttribution(credentials.attribution),
+              client: clientContextFromHeaders(req?.headers),
             }
           )
 


### PR DESCRIPTION
`signupDevice` resolved to `other` for every account, and outbound events carried the wrong browser context.

## Cause

The dashboard posts `/auth/register` and `/auth/google-login` to the API from its own server, through the NextAuth credentials provider. The request the API receives therefore belongs to that server, so `req.ip` and `req.headers['user-agent']` describe the proxy rather than the person signing up.

Confirmed in production: three consecutive real signups, all recorded as `other`.

## Fix

The NextAuth `authorize` callback does receive the browser's request as its second argument. The user agent and the first entry of `x-forwarded-for` are read there and forwarded in the request body. The API prefers the forwarded values and falls back per field to the request it received, so a direct API caller still behaves as before.

## The forwarded values are untrusted

They arrive in a request body on an unauthenticated endpoint, and the API has no global `ValidationPipe`, so `resolveRequestContext` is the only gate:

- strings only, so a query operator cannot pass through
- user agent capped at 512 characters
- control characters stripped, so a forwarded value cannot forge a log line
- the address must be address shaped

They label analytics only. Nothing here is used for authorisation, rate limiting, or any other decision, so the worst a forged value can do is skew our own reporting.

## Testing

522 API tests and 246 web tests pass. New coverage for the precedence rules, per-field fallback, and each rejection case including log-line injection and non-address text. No change to the OpenAPI spec beyond the new optional field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Registration and Google sign-in now include available browser and network context.
  - Client IP detection supports forwarded proxy headers and fallback request headers.
  - Browser information is safely limited and sanitized before being recorded.
  - Missing or invalid client details no longer prevent authentication requests from completing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->