### PR TITLE
Parse the forwarded IP address instead of pattern matching it

### DIFF
--- a/api/src/common/request-context.spec.ts
+++ b/api/src/common/request-context.spec.ts
@@ -72,17 +72,23 @@ describe('resolveRequestContext', () => {
       expect(result.userAgent).toBe('Mozilla/5.0[Nest] LOG fake entry')
     })
 
-    it('rejects an address that is not address shaped', () => {
-      for (const bad of [
-        'not-an-ip',
-        '<script>alert(1)</script>',
-        '203.0.113.4; DROP',
-        'x'.repeat(60),
-        '',
-        '   ',
-      ]) {
-        expect(resolveRequestContext({ ip: bad }, undefined).ip).toBeUndefined()
-      }
+    // The last six pass a character allowlist but are not addresses, which is
+    // why the check parses rather than pattern matches.
+    it.each([
+      'not-an-ip',
+      '<script>alert(1)</script>',
+      '203.0.113.4; DROP',
+      'x'.repeat(60),
+      '',
+      '   ',
+      '::::',
+      '203.0.113.999',
+      '1.2.3.4:5',
+      '1.2.3',
+      '1.2.3.4.5',
+      '...',
+    ])('rejects %s, which does not parse as an address', (bad) => {
+      expect(resolveRequestContext({ ip: bad }, undefined).ip).toBeUndefined()
     })
 
     it('accepts ordinary IPv4 and IPv6 forms', () => {

--- a/api/src/common/request-context.ts
+++ b/api/src/common/request-context.ts
@@ -7,8 +7,9 @@
 // never for authorisation or rate limiting, and are bounded here so a hostile
 // payload cannot grow a document or forge a log line.
 
+import { isIP } from 'net'
+
 const MAX_USER_AGENT = 512
-const MAX_IP = 45 // longest IPv6 form, including an embedded IPv4 tail
 
 // Control characters, which would otherwise let a forwarded value inject
 // newlines into logs.
@@ -33,10 +34,11 @@ function cleanUserAgent(value: unknown): string | undefined {
 function cleanIp(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined
   const trimmed = value.trim()
-  if (!trimmed || trimmed.length > MAX_IP) return undefined
-  // A shape check rather than a validity check: enough to keep arbitrary text
-  // out of the field without reimplementing an address parser.
-  return /^[0-9a-fA-F:.]+$/.test(trimmed) ? trimmed : undefined
+  // Parsed, not pattern matched. An allowlist of characters would accept
+  // "::::" and "203.0.113.999", and passing a malformed address to an ad
+  // platform is worse than passing none, which is the whole point of
+  // forwarding the real one.
+  return isIP(trimmed) ? trimmed : undefined
 }
 
 export function resolveRequestContext(


### PR DESCRIPTION
Follow-up to #328, from review feedback on that pull request.

The check there allowlisted characters rather than parsing, so `::::`, `203.0.113.999` and `1.2.3.4:5` all passed. Any of them would have overridden the request address and been sent onward as a client address.

That matters more than a normal validation gap: a malformed address degrades identity matching at the receiving end more than sending no address at all, which is the exact problem #328 existed to fix.

`net.isIP` from the Node standard library parses the value, so the length cap and the hand-rolled grammar both go away.

533 API tests pass, with the three cases above added as regressions alongside the existing ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of forwarded IP addresses to reject malformed values, including invalid numeric ranges and incorrect address formats.
  * Prevented address-like strings that pass basic character checks from being accepted as valid IP addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->