### PR TITLE
Fold a hostname utm_source into the same bucket as the referrer

### DIFF
--- a/api/src/users/attribution.spec.ts
+++ b/api/src/users/attribution.spec.ts
@@ -13,6 +13,20 @@ describe('normalizeSignupSource', () => {
     expect(normalizeSignupSource({ first: { landingPath: '/' } })).toBe('direct')
   })
 
+  it('folds a hostname utm_source into the same bucket as the referrer', () => {
+    // ChatGPT appends utm_source=chatgpt.com to links it surfaces, so without
+    // this the channel is split across two names.
+    expect(normalizeSignupSource({ first: { source: 'chatgpt.com' } })).toBe('chatgpt')
+    expect(normalizeSignupSource({ first: { referrer: 'chatgpt.com' } })).toBe('chatgpt')
+    expect(normalizeSignupSource({ first: { source: 'www.perplexity.ai' } })).toBe('perplexity')
+  })
+
+  it('leaves a plain utm_source alone', () => {
+    expect(normalizeSignupSource({ first: { source: 'meta' } })).toBe('meta')
+    expect(normalizeSignupSource({ first: { source: 'Newsletter' } })).toBe('newsletter')
+    expect(normalizeSignupSource({ first: { source: 'google' } })).toBe('google')
+  })
+
   it('prefers an explicit utm_source', () => {
     expect(
       normalizeSignupSource({

--- a/api/src/users/attribution.ts
+++ b/api/src/users/attribution.ts
@@ -139,8 +139,12 @@ export function normalizeSignupSource(
   const first = attribution?.first ?? attribution?.last
   if (!first) return 'direct'
 
+  // Run an explicit utm_source through the same host mapping. Some referrers
+  // set a hostname as the parameter, notably ChatGPT, which appends
+  // utm_source=chatgpt.com. Without this, the same channel lands in two
+  // buckets depending on whether the link carried the parameter.
   const source = cleanString(first.source)
-  if (source) return source.toLowerCase()
+  if (source) return normalizeReferrer(source)
 
   const ref = cleanString(first.ref)
   if (ref) return ref.toLowerCase()


### PR DESCRIPTION
Found in live data hours after the attribution work shipped.

Some referrers set a hostname as the campaign parameter rather than a channel name. ChatGPT is the notable one: it appends `utm_source=chatgpt.com` to links it surfaces. A visit carrying that parameter was recorded as `chatgpt.com`, while a visit identified only by its referrer was recorded as `chatgpt`.

One channel, two buckets. Every report that groups by source understates it, and the split compounds the longer it runs.

An explicit `utm_source` now passes through the same host mapping a referrer already does. Values that are not hostnames are untouched, so `meta`, `reddit` and `newsletter` still record as themselves, and `google` stays `google` because the search-engine pattern requires a dot.

535 API tests pass, with cases covering both spellings resolving to one bucket and plain sources being left alone.

Production currently holds a single affected row, so this lands before the data matters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Signup source tracking now consistently groups hostname-style campaign sources with their corresponding referral channels.
  * Standard campaign sources continue to be normalized to lowercase without changing their channel names.

* **Tests**
  * Added coverage for hostname-based and standard campaign source values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->