### PR TITLE
Never record an empty signup source

### DIFF
--- a/api/src/users/attribution.spec.ts
+++ b/api/src/users/attribution.spec.ts
@@ -21,6 +21,12 @@ describe('normalizeSignupSource', () => {
     expect(normalizeSignupSource({ first: { source: 'www.perplexity.ai' } })).toBe('perplexity')
   })
 
+  it('never returns an empty source, even when normalisation empties it', () => {
+    // "www." survives cleanString but the host mapping strips it to nothing.
+    expect(normalizeSignupSource({ first: { source: 'www.' } })).toBe('www.')
+    expect(normalizeSignupSource({ first: { referrer: 'www.' } })).toBe('direct')
+  })
+
   it('leaves a plain utm_source alone', () => {
     expect(normalizeSignupSource({ first: { source: 'meta' } })).toBe('meta')
     expect(normalizeSignupSource({ first: { source: 'Newsletter' } })).toBe('newsletter')

--- a/api/src/users/attribution.ts
+++ b/api/src/users/attribution.ts
@@ -144,7 +144,11 @@ export function normalizeSignupSource(
   // utm_source=chatgpt.com. Without this, the same channel lands in two
   // buckets depending on whether the link carried the parameter.
   const source = cleanString(first.source)
-  if (source) return normalizeReferrer(source)
+  if (source) {
+    // Normalisation can empty a value that was not empty, for example a bare
+    // "www.", and an empty source is worse than an unmapped one.
+    return normalizeReferrer(source) || source.toLowerCase()
+  }
 
   const ref = cleanString(first.ref)
   if (ref) return ref.toLowerCase()
@@ -153,7 +157,13 @@ export function normalizeSignupSource(
   if (cleanString(first.fbclid)) return 'meta'
 
   const referrer = cleanString(first.referrer)
-  if (referrer) return normalizeReferrer(referrer)
+  if (referrer) {
+    // Same guard as above, but the conclusion differs: an explicit utm_source
+    // is intentional and worth keeping verbatim, whereas a referrer that
+    // normalises to nothing tells us nothing, so it falls through to direct.
+    const normalized = normalizeReferrer(referrer)
+    if (normalized) return normalized
+  }
 
   return 'direct'
 }


### PR DESCRIPTION
Follow-up to #330, from review feedback on it.

Host normalisation can empty a value that was not empty. A bare `www.` survives `cleanString`, but the mapping strips the prefix and returns nothing, so `signupSource` was stored as an empty string and every remaining rule was skipped.

Both paths now guard the result, and they deliberately differ:

- an explicit `utm_source` is intentional, so it is kept verbatim when normalisation empties it
- a referrer that normalises to nothing carries no information, so it falls through to `direct`

The review raised the `utm_source` half. The referrer half has the same flaw and was caught by the regression test written for the first one.

535 API tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Signup attribution now preserves valid `utm_source` values even when the referrer cannot be normalized.
  - Referrer values that normalize to an empty result now correctly fall back to **Direct** attribution.
  - Edge cases involving short or incomplete referrer values are handled more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->