### PR TITLE
Normalise app referrers and bound untrusted touch timestamps

### DIFF
--- a/api/src/analytics/meta-capi.service.spec.ts
+++ b/api/src/analytics/meta-capi.service.spec.ts
@@ -95,6 +95,22 @@ describe('MetaCapiService', () => {
     expect(lastBody().data[0].user_data.fbp).toBe('fb.1.1757577600000.99')
   })
 
+  it('never reports a click from the future', async () => {
+    // The click time came from a browser clock, which can run ahead.
+    const before = Date.now()
+    await service.send({
+      name: 'CompleteRegistration',
+      user: {
+        userId: 'user-3',
+        fbclid: 'click-2',
+        fbclidAt: new Date(before + 10 * 60 * 1000),
+      },
+    })
+    const stamp = Number(lastBody().data[0].user_data.fbc.split('.')[2])
+    expect(stamp).toBeGreaterThanOrEqual(before)
+    expect(stamp).toBeLessThanOrEqual(Date.now())
+  })
+
   it('passes browser context only when there is any', async () => {
     await service.send({
       name: 'Purchase',

--- a/api/src/analytics/meta-capi.service.ts
+++ b/api/src/analytics/meta-capi.service.ts
@@ -54,9 +54,11 @@ export class MetaCapiService {
     if (user.fbp) data.fbp = user.fbp
 
     // Meta's documented click-id format: fb.<subdomain index>.<click time in
-    // milliseconds>.<fbclid>.
+    // milliseconds>.<fbclid>. The click time came from a browser clock, so it
+    // is never allowed to sit in the future.
     if (user.fbclid) {
-      const clickedAt = user.fbclidAt?.getTime() ?? Date.now()
+      const now = Date.now()
+      const clickedAt = Math.min(user.fbclidAt?.getTime() ?? now, now)
       data.fbc = `fb.1.${clickedAt}.${user.fbclid}`
     }
 

--- a/api/src/auth/auth.dto.ts
+++ b/api/src/auth/auth.dto.ts
@@ -84,7 +84,32 @@ export class AttributionTouchDTO {
   at?: string
 }
 
+export class AttributionEntryDTO {
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Path of the very first page this person opened.',
+    example: '/',
+  })
+  landingPath?: string
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'When that first visit happened, as an ISO timestamp.',
+  })
+  at?: string
+}
+
 export class AttributionDTO {
+  @ApiProperty({
+    type: AttributionEntryDTO,
+    required: false,
+    description:
+      'The first visit ever, recorded even when it carried no source. Never used for credit.',
+  })
+  entry?: AttributionEntryDTO
+
   @ApiProperty({
     type: AttributionTouchDTO,
     required: false,

--- a/api/src/users/attribution.spec.ts
+++ b/api/src/users/attribution.spec.ts
@@ -11,6 +11,19 @@ describe('normalizeSignupSource', () => {
     expect(normalizeSignupSource(null)).toBe('direct')
     expect(normalizeSignupSource({})).toBe('direct')
     expect(normalizeSignupSource({ first: { landingPath: '/' } })).toBe('direct')
+    // An entry records where a direct visit landed and must never earn credit.
+    expect(normalizeSignupSource({ entry: { landingPath: '/pricing' } })).toBe(
+      'direct',
+    )
+  })
+
+  it('names the app behind an Android in-app browser referrer', () => {
+    expect(
+      normalizeSignupSource({ first: { referrer: 'org.telegram.messenger' } }),
+    ).toBe('telegram')
+    expect(
+      normalizeSignupSource({ first: { referrer: 'com.instagram.android' } }),
+    ).toBe('meta')
   })
 
   it('folds a hostname utm_source into the same bucket as the referrer', () => {
@@ -97,15 +110,52 @@ describe('normalizeReferrer', () => {
     ['youtu.be', 'youtube'],
     ['news.ycombinator.com', 'hackernews'],
     ['producthunt.com', 'producthunt'],
+    ['search.brave.com', 'brave'],
+    ['startpage.com', 'startpage'],
+    ['kagi.com', 'kagi'],
+    ['search.yahoo.com', 'yahoo'],
+    ['baidu.com', 'baidu'],
+    ['mail.google.com', 'gmail'],
+    ['news.google.com', 'google-news'],
   ]
 
   it.each(cases)('maps %s to %s', (host, expected) => {
     expect(normalizeReferrer(host)).toBe(expected)
   })
 
+  // Android in-app browsers send android-app://<package>/ as the referrer, so
+  // the host that reaches here is a package name, not a domain.
+  const appCases: Array<[string, string]> = [
+    ['com.instagram.android', 'meta'],
+    ['com.facebook.katana', 'meta'],
+    ['com.facebook.lite', 'meta'],
+    ['com.facebook.orca', 'meta'],
+    ['com.twitter.android', 'x'],
+    ['com.reddit.frontpage', 'reddit'],
+    ['com.linkedin.android', 'linkedin'],
+    ['org.telegram.messenger', 'telegram'],
+    ['com.whatsapp', 'whatsapp'],
+    ['com.discord', 'discord'],
+    ['com.Slack', 'slack'],
+    ['com.microsoft.teams', 'teams'],
+    ['com.google.android.gm', 'gmail'],
+    ['com.google.android.googlequicksearchbox', 'google'],
+  ]
+
+  it.each(appCases)('maps the %s app to %s', (pkg, expected) => {
+    expect(normalizeReferrer(pkg)).toBe(expected)
+  })
+
   it('does not let a search engine domain swallow its assistant', () => {
     expect(normalizeReferrer('gemini.google.com')).toBe('gemini')
     expect(normalizeReferrer('www.google.com')).toBe('google')
+  })
+
+  it('does not let Google search swallow Gmail', () => {
+    // Gmail sits on google.com, and the generic google rule would otherwise
+    // count every emailed link as an organic search visit.
+    expect(normalizeReferrer('mail.google.com')).toBe('gmail')
+    expect(normalizeReferrer('google.com')).toBe('google')
   })
 
   it('keeps an unrecognised host so a new channel is still visible', () => {
@@ -135,9 +185,9 @@ describe('classifyDevice', () => {
     )
   })
 
-  it('returns other rather than guessing', () => {
-    expect(classifyDevice(undefined)).toBe('other')
-    expect(classifyDevice('')).toBe('other')
+  it('tells a missing user agent apart from one it cannot place', () => {
+    expect(classifyDevice(undefined)).toBe('unknown')
+    expect(classifyDevice('')).toBe('unknown')
     expect(classifyDevice('curl/8.4.0')).toBe('other')
   })
 })
@@ -203,14 +253,38 @@ describe('sanitizeAttribution', () => {
   })
 
   it('parses a valid timestamp and drops an invalid one', () => {
-    expect(
-      sanitizeAttribution({ first: { at: '2026-09-11T10:00:00.000Z' } })?.first
-        ?.at,
-    ).toEqual(new Date('2026-09-11T10:00:00.000Z'))
+    const recent = new Date(Date.now() - 60_000).toISOString()
+    expect(sanitizeAttribution({ first: { at: recent } })?.first?.at).toEqual(
+      new Date(recent),
+    )
 
     expect(
       sanitizeAttribution({ first: { source: 'meta', at: 'never' } })?.first?.at,
     ).toBeUndefined()
+  })
+
+  it('tolerates ordinary clock skew but not a fictional time', () => {
+    const at = (offsetMs: number) =>
+      sanitizeAttribution({
+        first: { source: 'meta', at: new Date(Date.now() + offsetMs).toISOString() },
+      })?.first?.at
+
+    // A browser clock two minutes fast is normal and worth keeping.
+    expect(at(2 * 60 * 1000)).toBeInstanceOf(Date)
+    // An hour in the future, or older than the cookie could possibly be, is not.
+    expect(at(60 * 60 * 1000)).toBeUndefined()
+    expect(at(-500 * 24 * 60 * 60 * 1000)).toBeUndefined()
+  })
+
+  it('keeps the entry with only its own two fields', () => {
+    const result = sanitizeAttribution({
+      entry: { landingPath: '/pricing', at: 'never', source: 'sneaky' },
+    })
+    expect(result?.entry).toEqual({ landingPath: '/pricing' })
+    expect(result?.first).toBeUndefined()
+
+    expect(sanitizeAttribution({ entry: {} })).toBeUndefined()
+    expect(sanitizeAttribution({ entry: 'meta' })).toBeUndefined()
   })
 
   it('stamps when it was captured', () => {

--- a/api/src/users/attribution.ts
+++ b/api/src/users/attribution.ts
@@ -17,7 +17,16 @@ export type AttributionTouchInput = {
   at?: string | Date
 }
 
+// The very first visit, whether or not it carried a source. Kept apart from
+// first-touch so a plain direct visit never claims credit from a later
+// campaign click.
+export type AttributionEntryInput = {
+  landingPath?: string
+  at?: Date
+}
+
 export type AttributionInput = {
+  entry?: AttributionEntryInput
   first?: AttributionTouchInput
   last?: AttributionTouchInput
   fbp?: string
@@ -40,11 +49,38 @@ const TOUCH_STRING_FIELDS = [
 const MAX_FIELD_LENGTH = 200
 const MAX_KEYS = 20
 
+// A browser clock is not trusted for the visit time. Slightly ahead is
+// ordinary skew; far ahead or absurdly old is a fiction and is dropped.
+const MAX_FUTURE_SKEW_MS = 5 * 60 * 1000
+const MAX_TOUCH_AGE_MS = 400 * 24 * 60 * 60 * 1000
+
+// Android in-app browsers report the referrer as android-app://<package>/,
+// so the "host" that reaches here is a package name. Without this table an
+// Instagram tap shows up as com.instagram.android rather than meta.
+const APP_REFERRERS: Record<string, string> = {
+  'com.instagram.android': 'meta',
+  'com.facebook.katana': 'meta',
+  'com.facebook.lite': 'meta',
+  'com.facebook.orca': 'meta',
+  'com.twitter.android': 'x',
+  'com.reddit.frontpage': 'reddit',
+  'com.linkedin.android': 'linkedin',
+  'org.telegram.messenger': 'telegram',
+  'org.telegram.plus': 'telegram',
+  'com.whatsapp': 'whatsapp',
+  'com.discord': 'discord',
+  'com.slack': 'slack',
+  'com.microsoft.teams': 'teams',
+  'com.google.android.gm': 'gmail',
+  'com.google.android.googlequicksearchbox': 'google',
+}
+
 // Referrer hosts worth naming. Anything unlisted falls through to its bare
 // hostname, which keeps a new channel visible in reports without a code change.
-// Order matters. The assistants come first because several of them sit on a
-// search engine's domain: gemini.google.com would otherwise be counted as
-// Google search and quietly understate AI referrals.
+// Order matters. Several entries sit on a search engine's domain and must
+// precede its catch-all rule: gemini.google.com would otherwise be counted as
+// Google search, and mail.google.com would turn every Gmail link into an
+// organic search visit.
 const REFERRER_SOURCES: Array<[RegExp, string]> = [
   [/(^|\.)chatgpt\.com$/, 'chatgpt'],
   [/(^|\.)openai\.com$/, 'chatgpt'],
@@ -56,11 +92,21 @@ const REFERRER_SOURCES: Array<[RegExp, string]> = [
   [/(^|\.)meta\.ai$/, 'meta-ai'],
   [/(^|\.)(facebook|instagram)\.com$/, 'meta'],
   [/(^|\.)messenger\.com$/, 'meta'],
+  [/^mail\.google\.com$/, 'gmail'],
+  [/^news\.google\.com$/, 'google-news'],
   [/(^|\.)google\./, 'google'],
   [/(^|\.)bing\.com$/, 'bing'],
   [/(^|\.)duckduckgo\.com$/, 'duckduckgo'],
   [/(^|\.)ecosia\.org$/, 'ecosia'],
   [/(^|\.)yandex\./, 'yandex'],
+  [/(^|\.)brave\.com$/, 'brave'],
+  [/(^|\.)startpage\.com$/, 'startpage'],
+  [/(^|\.)qwant\.com$/, 'qwant'],
+  [/(^|\.)mojeek\.com$/, 'mojeek'],
+  [/(^|\.)kagi\.com$/, 'kagi'],
+  [/(^|\.)yahoo\./, 'yahoo'],
+  [/(^|\.)baidu\.com$/, 'baidu'],
+  [/(^|\.)naver\.com$/, 'naver'],
   [/(^|\.)github\.com$/, 'github'],
   [/(^|\.)reddit\.com$/, 'reddit'],
   [/(^|\.)(x|twitter)\.com$/, 'x'],
@@ -79,6 +125,16 @@ function cleanString(value: unknown): string | undefined {
   return trimmed || undefined
 }
 
+function cleanTimestamp(value: unknown, now = Date.now()): Date | undefined {
+  if (typeof value !== 'string' && !(value instanceof Date)) return undefined
+  const parsed = new Date(value)
+  const time = parsed.getTime()
+  if (Number.isNaN(time)) return undefined
+  if (time > now + MAX_FUTURE_SKEW_MS) return undefined
+  if (time < now - MAX_TOUCH_AGE_MS) return undefined
+  return parsed
+}
+
 function sanitizeTouch(value: unknown): AttributionTouchInput | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return undefined
@@ -94,12 +150,26 @@ function sanitizeTouch(value: unknown): AttributionTouchInput | undefined {
       const cleaned = cleanString(input[key])
       if (cleaned) touch[key] = cleaned
     } else if (key === 'at') {
-      const parsed = new Date(input[key] as string)
-      if (!Number.isNaN(parsed.getTime())) touch.at = parsed
+      const at = cleanTimestamp(input[key])
+      if (at) touch.at = at
     }
   }
 
   return Object.keys(touch).length ? (touch as AttributionTouchInput) : undefined
+}
+
+function sanitizeEntry(value: unknown): AttributionEntryInput | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined
+  }
+  const input = value as Record<string, unknown>
+  const landingPath = cleanString(input.landingPath)
+  const at = cleanTimestamp(input.at)
+  if (!landingPath && !at) return undefined
+  return {
+    ...(landingPath && { landingPath }),
+    ...(at && { at }),
+  }
 }
 
 export function sanitizeAttribution(value: unknown): AttributionInput | undefined {
@@ -108,13 +178,15 @@ export function sanitizeAttribution(value: unknown): AttributionInput | undefine
   }
   const input = value as Record<string, unknown>
 
+  const entry = sanitizeEntry(input.entry)
   const first = sanitizeTouch(input.first)
   const last = sanitizeTouch(input.last)
   const fbp = cleanString(input.fbp)
 
-  if (!first && !last && !fbp) return undefined
+  if (!entry && !first && !last && !fbp) return undefined
 
   return {
+    ...(entry && { entry }),
     ...(first && { first }),
     ...(last && { last }),
     ...(fbp && { fbp }),
@@ -125,6 +197,8 @@ export function sanitizeAttribution(value: unknown): AttributionInput | undefine
 export function normalizeReferrer(referrer: string): string {
   const host = referrer.trim().toLowerCase().replace(/^www\./, '')
   if (!host) return ''
+  const app = APP_REFERRERS[host]
+  if (app) return app
   for (const [pattern, name] of REFERRER_SOURCES) {
     if (pattern.test(host)) return name
   }
@@ -170,9 +244,10 @@ export function normalizeSignupSource(
 
 // The device an advert was seen on, which is not proof of what hardware the
 // person owns. Reported against milestones.firstDeviceAt rather than used to
-// exclude anyone.
+// exclude anyone. "unknown" means no user agent reached us at all, which is
+// a different fact from "other", a user agent we could not place.
 export function classifyDevice(userAgent?: string): string {
-  if (!userAgent) return 'other'
+  if (!userAgent) return 'unknown'
   const ua = userAgent.toLowerCase()
   if (ua.includes('android')) return 'android'
   if (/iphone|ipad|ipod/.test(ua)) return 'ios'

--- a/api/src/users/schemas/user.schema.ts
+++ b/api/src/users/schemas/user.schema.ts
@@ -45,8 +45,25 @@ export class AttributionTouch {
 
 const AttributionTouchSchema = SchemaFactory.createForClass(AttributionTouch)
 
+// The first visit ever, source or not. Kept separate from first-touch so a
+// direct visit records where it landed without claiming credit from a later
+// campaign click.
+@Schema({ _id: false })
+export class AttributionEntry {
+  @Prop({ type: String })
+  landingPath?: string
+
+  @Prop({ type: Date })
+  at?: Date
+}
+
+const AttributionEntrySchema = SchemaFactory.createForClass(AttributionEntry)
+
 @Schema({ _id: false })
 export class Attribution {
+  @Prop({ type: AttributionEntrySchema })
+  entry?: AttributionEntry
+
   @Prop({ type: AttributionTouchSchema })
   first?: AttributionTouch
 

--- a/api/src/users/users.service.spec.ts
+++ b/api/src/users/users.service.spec.ts
@@ -49,7 +49,7 @@ describe('UsersService - signup attribution', () => {
     await service.create({ name: 'Ada', email: 'ada@example.com' })
 
     expect(saved[0].signupSource).toBe('direct')
-    expect(saved[0].signupDevice).toBe('other')
+    expect(saved[0].signupDevice).toBe('unknown')
   })
 
   it('defaults the marketing opt in to false', async () => {

--- a/web/lib/analytics/attribution.test.ts
+++ b/web/lib/analytics/attribution.test.ts
@@ -127,8 +127,30 @@ describe('touchCounts', () => {
 })
 
 describe('mergeAttribution', () => {
-  it('stores nothing for a direct visit with no source', () => {
-    expect(mergeAttribution(null, { landingPath: '/' })).toBeNull()
+  it('records only where a direct visit landed, with no touch', () => {
+    const merged = mergeAttribution(null, {
+      landingPath: '/pricing',
+      at: NOW.toISOString(),
+    })
+    expect(merged).toEqual({
+      entry: { landingPath: '/pricing', at: NOW.toISOString() },
+    })
+  })
+
+  it('lets a later campaign click take first touch after a direct entry', () => {
+    // A direct visit must not steal credit from the ad that came after it, so
+    // the entry is kept apart from first-touch rather than folded into it.
+    const direct = mergeAttribution(null, { landingPath: '/', at: '1' })
+    const later = mergeAttribution(direct, { source: 'meta', at: '2' })
+    expect(later?.entry).toEqual({ landingPath: '/', at: '1' })
+    expect(later?.first?.source).toBe('meta')
+    expect(later?.last?.source).toBe('meta')
+  })
+
+  it('never rewrites the entry once set', () => {
+    const first = mergeAttribution(null, { source: 'meta', landingPath: '/a' })
+    const second = mergeAttribution(first, { source: 'reddit', landingPath: '/b' })
+    expect(second?.entry?.landingPath).toBe('/a')
   })
 
   it('sets first and last on the first campaign visit', () => {
@@ -170,17 +192,60 @@ describe('parseAttribution', () => {
     expect(parsed?.first).toEqual({ source: 'meta' })
     expect(parsed?.last).toEqual({ source: 'reddit' })
   })
+
+  it('keeps an entry-only cookie and scrubs junk inside it', () => {
+    const parsed = parseAttribution(
+      JSON.stringify({ entry: { landingPath: '/docs', at: 'x', evil: 1 } })
+    )
+    expect(parsed).toEqual({ entry: { landingPath: '/docs', at: 'x' } })
+  })
 })
 
 describe('serializeAttribution', () => {
   it('round-trips a normal value untouched', () => {
     const attribution: Attribution = {
+      entry: { landingPath: '/', at: NOW.toISOString() },
       first: { source: 'meta', campaign: 'c1' },
       last: { source: 'reddit' },
     }
     expect(parseAttribution(serializeAttribution(attribution))).toEqual(
       attribution
     )
+  })
+
+  it('sheds last touch before the entry, and the entry before first touch', () => {
+    const long = 'x'.repeat(200)
+    const fatTouch = {
+      source: long,
+      medium: long,
+      campaign: long,
+      content: long,
+      term: long,
+      ref: long,
+      referrer: long,
+      landingPath: long,
+      fbclid: long,
+      gclid: long,
+    }
+    const entry = { landingPath: '/', at: NOW.toISOString() }
+
+    // Two fat touches do not fit; one fat touch plus the entry does.
+    const shedLast = parseAttribution(
+      serializeAttribution({ entry, first: fatTouch, last: fatTouch })
+    )
+    expect(shedLast?.last).toBeUndefined()
+    expect(shedLast?.entry).toEqual(entry)
+    expect(shedLast?.first?.source).toBe(long)
+
+    // A single touch so fat that even the tiny entry tips it over.
+    const enormous = { ...fatTouch, source: 'y'.repeat(200) }
+    const stillFat = parseAttribution(
+      serializeAttribution({
+        entry: { landingPath: 'z'.repeat(200), at: NOW.toISOString() },
+        first: enormous,
+      })
+    )
+    expect(stillFat?.first?.source).toBeTruthy()
   })
 
   it('sheds data rather than letting the browser drop an oversized cookie', () => {

--- a/web/lib/analytics/attribution.ts
+++ b/web/lib/analytics/attribution.ts
@@ -22,7 +22,16 @@ export type Touch = {
   at?: string
 }
 
+// The very first visit, whether or not it carried a source. Kept apart from
+// first-touch so a plain direct visit never claims credit from a later
+// campaign click; it only records where that person first landed.
+export type Entry = {
+  landingPath?: string
+  at?: string
+}
+
 export type Attribution = {
+  entry?: Entry
   first?: Touch
   last?: Touch
   fbp?: string
@@ -120,8 +129,11 @@ export function mergeAttribution(
 ): Attribution | null {
   const counts = touchCounts(touch)
 
+  // The entry is written exactly once, on the first visit this browser has
+  // ever made, and is never revisited afterwards.
   if (!existing) {
-    return counts ? { first: touch, last: touch } : null
+    const entry: Entry = { landingPath: touch.landingPath, at: touch.at }
+    return counts ? { entry, first: touch, last: touch } : { entry }
   }
   if (!counts) return existing
 
@@ -142,17 +154,33 @@ function sanitizeTouch(value: unknown): Touch | undefined {
   return Object.keys(touch).length ? touch : undefined
 }
 
+function sanitizeEntry(value: unknown): Entry | undefined {
+  if (!value || typeof value !== 'object') return undefined
+  const input = value as Record<string, unknown>
+  const entry: Entry = {}
+  const landingPath =
+    typeof input.landingPath === 'string' ? clean(input.landingPath) : undefined
+  const at = typeof input.at === 'string' ? clean(input.at) : undefined
+  if (landingPath) entry.landingPath = landingPath
+  if (at) entry.at = at
+  return Object.keys(entry).length ? entry : undefined
+}
+
 export function parseAttribution(raw: string | null): Attribution | null {
   if (!raw) return null
   try {
     const parsed = JSON.parse(raw) as Record<string, unknown>
     if (!parsed || typeof parsed !== 'object') return null
     const attribution: Attribution = {}
+    const entry = sanitizeEntry(parsed.entry)
     const first = sanitizeTouch(parsed.first)
     const last = sanitizeTouch(parsed.last)
+    if (entry) attribution.entry = entry
     if (first) attribution.first = first
     if (last) attribution.last = last
-    return attribution.first || attribution.last ? attribution : null
+    return attribution.entry || attribution.first || attribution.last
+      ? attribution
+      : null
   } catch {
     return null
   }
@@ -160,16 +188,25 @@ export function parseAttribution(raw: string | null): Attribution | null {
 
 // Browsers drop an oversized cookie silently, which would lose attribution
 // with no error, so shed data until it fits rather than risk the whole value.
+// Last touch goes first, then the entry, and first touch is kept to the end
+// because it is the one that decides credit.
 export function serializeAttribution(attribution: Attribution): string {
-  let candidate: Attribution = attribution
-  let encoded = encodeURIComponent(JSON.stringify(candidate))
-  if (encoded.length <= MAX_COOKIE_LENGTH) return JSON.stringify(candidate)
+  const fits = (candidate: Attribution) =>
+    encodeURIComponent(JSON.stringify(candidate)).length <= MAX_COOKIE_LENGTH
 
-  candidate = { first: attribution.first ?? attribution.last }
-  encoded = encodeURIComponent(JSON.stringify(candidate))
-  if (encoded.length <= MAX_COOKIE_LENGTH) return JSON.stringify(candidate)
+  if (fits(attribution)) return JSON.stringify(attribution)
 
-  const touch = candidate.first ?? {}
+  const first = attribution.first ?? attribution.last
+  const withEntry: Attribution = {
+    ...(attribution.entry && { entry: attribution.entry }),
+    ...(first && { first }),
+  }
+  if (fits(withEntry)) return JSON.stringify(withEntry)
+
+  const firstOnly: Attribution = { ...(first && { first }) }
+  if (fits(firstOnly)) return JSON.stringify(firstOnly)
+
+  const touch = first ?? {}
   const trimmed: Touch = {}
   for (const field of TOUCH_FIELDS) {
     const value = touch[field]


### PR DESCRIPTION
Follow-up to the attribution work, from reading what the fields actually recorded.

- Android in-app browsers report `android-app://<package>/` as the referrer, so the host reaching the normaliser is a package name. The common ones are now mapped instead of stored raw.
- Added the search engines that were still unmapped, and split `mail.google.com` and `news.google.com` ahead of the generic `google.` rule, which was counting emailed links as organic search.
- A visit that carries no source now records where it landed, in a field of its own. Widening first touch instead would let it take credit from a later campaign click.
- The visit time comes from a browser clock, so one far in the future or older than the cookie can be is dropped, and a click id is never stamped ahead of now.
- `classifyDevice` reports `unknown` when no user agent reached us, which is a different fact from `other`.

Tests cover every mapping, the shed order on an oversized cookie, and the clock bounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * First visits are now recorded separately from attribution credit, including the landing page and visit time.
  * Attribution recognizes additional Android in-app browsers, email services, and search engines.
  * Direct visits can be retained without overwriting existing first-touch or entry information.
* **Bug Fixes**
  * Invalid, outdated, or future-dated attribution timestamps are filtered or corrected.
  * Browser click timestamps sent to Meta are prevented from being set in the future.
* **Improvements**
  * Attribution data is preserved more reliably when browser storage limits are reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->