### PR TITLE
fix(api): await SMS batch status update to processing

### DIFF
--- a/api/src/gateway/queue/sms-queue.processor.ts
+++ b/api/src/gateway/queue/sms-queue.processor.ts
@@ -91,18 +91,11 @@ export class SmsQueueProcessor {
     }
 
     try {
-      this.smsBatchModel
+      await this.smsBatchModel
         .findByIdAndUpdate(smsBatchId, {
           $set: { status: 'processing' },
         })
         .exec()
-        .catch((error) => {
-          this.logger.error(
-            `Failed to update sms batch status to processing ${smsBatchId}`,
-            error,
-          )
-          throw error
-        })
 
       const skipped = shouldSkipFcmSend(device?.user, deviceId)
       const response = skipped


### PR DESCRIPTION
## Summary
The SMS queue processor fired `findByIdAndUpdate(... status: processing)` without `await`, so failures became unhandled rejections and batches could stay `pending` even after messages were sent.

## Changes
- `await` the batch status update
- Drop the inner `.catch` rethrow (outer try/catch handles it)

Closes #279

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SMS batch error handling so processing failures are consistently logged and all affected SMS records are marked as failed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->